### PR TITLE
Voiding boilers fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 /run/
 /build/
 /eclipse/
+.vscode
 .classpath
 .project
 /bin/

--- a/build.gradle
+++ b/build.gradle
@@ -1,4 +1,4 @@
-//version: 8fa7883b6196c1765266f4e6ddf3118d5043aafb
+//version: 1641429628
 /*
 DO NOT CHANGE THIS FILE!
 
@@ -32,7 +32,7 @@ buildscript {
         }
     }
     dependencies {
-        classpath 'com.github.GTNewHorizons:ForgeGradle:1.2.4'
+        classpath 'com.github.GTNewHorizons:ForgeGradle:1.2.5'
     }
 }
 

--- a/src/main/java/mods/railcraft/common/blocks/machine/beta/TileBoilerFirebox.java
+++ b/src/main/java/mods/railcraft/common/blocks/machine/beta/TileBoilerFirebox.java
@@ -28,6 +28,7 @@ import mods.railcraft.common.plugins.buildcraft.triggers.ITemperature;
 import mods.railcraft.common.util.inventory.wrappers.InventoryMapper;
 import mods.railcraft.common.util.inventory.StandaloneInventory;
 import mods.railcraft.common.fluids.FluidHelper;
+import mods.railcraft.common.fluids.FluidItemHelper;
 import mods.railcraft.common.util.misc.Game;
 import mods.railcraft.common.util.misc.ITileFilter;
 import mods.railcraft.common.util.steam.Steam;
@@ -144,7 +145,10 @@ public abstract class TileBoilerFirebox extends TileBoiler implements IInventory
     protected abstract void process();
 
     protected void processBuckets() {
-        FluidHelper.drainContainers(this, inventory, SLOT_LIQUID_INPUT, SLOT_LIQUID_OUTPUT);
+        FluidStack fluidStack = FluidItemHelper.getFluidStackInContainer(getStackInSlot(SLOT_LIQUID_INPUT));
+        if ( (fluidStack != null) && this.fill(ForgeDirection.UNKNOWN, fluidStack, false) > 0) {
+            FluidHelper.drainContainers(this, inventory, SLOT_LIQUID_INPUT, SLOT_LIQUID_OUTPUT);
+        }
     }
 
     @Override

--- a/src/main/java/mods/railcraft/common/blocks/machine/beta/TileBoilerFireboxFluid.java
+++ b/src/main/java/mods/railcraft/common/blocks/machine/beta/TileBoilerFireboxFluid.java
@@ -93,13 +93,6 @@ public class TileBoilerFireboxFluid extends TileBoilerFirebox {
     }
 
     @Override
-    protected void processBuckets() {
-        super.processBuckets();
-
-        FluidHelper.drainContainers(this, inventory, SLOT_LIQUID_INPUT, SLOT_LIQUID_OUTPUT);
-    }
-
-    @Override
     public boolean canFill(ForgeDirection from, Fluid fluid) {
         if (fluid == null) return false;
         if (FuelManager.getBoilerFuelValue(fluid) > 0) return true;

--- a/src/main/java/mods/railcraft/common/gui/containers/ContainerBoilerFluid.java
+++ b/src/main/java/mods/railcraft/common/gui/containers/ContainerBoilerFluid.java
@@ -15,7 +15,7 @@ import net.minecraft.inventory.ICrafting;
 import net.minecraft.inventory.Slot;
 import mods.railcraft.common.blocks.machine.beta.TileBoilerFireboxFluid;
 import mods.railcraft.common.gui.widgets.IndicatorWidget;
-import mods.railcraft.common.gui.slots.SlotFluidContainerFilled;
+import mods.railcraft.common.gui.slots.SlotBoilerFluidContainerFilled;
 import mods.railcraft.common.gui.slots.SlotOutput;
 import mods.railcraft.common.gui.widgets.FluidGaugeWidget;
 import mods.railcraft.common.fluids.TankManager;
@@ -38,7 +38,7 @@ public class ContainerBoilerFluid extends RailcraftContainer {
 
         addWidget(new IndicatorWidget(tile.boiler.heatIndicator, 40, 25, 176, 61, 6, 43));
 
-        addSlot(new SlotFluidContainerFilled(tile, 0, 143, 21));
+        addSlot(new SlotBoilerFluidContainerFilled(tile, 0, 143, 21));
         addSlot(new SlotOutput(tile, 1, 143, 56));
 
         for (int i = 0; i < 3; i++) {

--- a/src/main/java/mods/railcraft/common/gui/slots/SlotBoilerFluidContainerFilled.java
+++ b/src/main/java/mods/railcraft/common/gui/slots/SlotBoilerFluidContainerFilled.java
@@ -1,0 +1,24 @@
+package mods.railcraft.common.gui.slots;
+
+import mods.railcraft.api.fuel.FuelManager;
+import mods.railcraft.common.fluids.FluidItemHelper;
+import mods.railcraft.common.fluids.Fluids;
+import net.minecraft.inventory.IInventory;
+import net.minecraft.item.ItemStack;
+import net.minecraftforge.fluids.Fluid;
+
+public class SlotBoilerFluidContainerFilled extends SlotFluidContainerFilled {
+
+    public SlotBoilerFluidContainerFilled(IInventory iinventory, int slotIndex, int posX, int posY) {
+        super(iinventory, slotIndex, posX, posY);
+    }
+    
+        
+    @Override
+    public boolean isItemValid(ItemStack itemstack)
+    {   
+        Fluid fluid = FluidItemHelper.getFluidInContainer(itemstack);
+        return super.isItemValid(itemstack) && (FuelManager.getBoilerFuelValue(fluid) > 0 || Fluids.WATER.is(fluid));
+    }
+    
+}


### PR DESCRIPTION
Fixes GTNewHorizons/GT-New-Horizons-Modpack#4953.

- Fluid boilers GUIs only accept valid fluids
- Fluid and solid boilers only drain liquid containers when they have space for their contents

Note: IC2 "Water Cell" items still lose their containers when they're drained but that's a separate bug.