### PR TITLE
Fix #9093: Advanced Coke Oven makes Coal Coke from Charcoal

### DIFF
--- a/src/main/java/mods/railcraft/common/modules/ModuleFactory.java
+++ b/src/main/java/mods/railcraft/common/modules/ModuleFactory.java
@@ -94,7 +94,7 @@ public class ModuleFactory extends RailcraftModule {
                     RailcraftItem.plate.getRecipeObject(EnumPlate.STEEL));
 
         RailcraftCraftingManager.blastFurnace.addRecipe(
-                new ItemStack(Items.coal), false, false, 20, RailcraftToolItems.getCoalCoke());
+                new ItemStack(Items.coal, 1, 0), true, false, 20, RailcraftToolItems.getCoalCoke());
         RailcraftCraftingManager.blastFurnace.addRecipe(
                 new ItemStack(Blocks.coal_block), false, false, 180, EnumCube.COKE_BLOCK.getItem());
 


### PR DESCRIPTION
This is a fix for https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/9093

The ItemStack for coal in the recipe was not set to include the metadata of the item, so it was allowing both coal and charcoal to be used for the recipe since they share the same base item. This just updates the acceptable ItemStack to explicitly only allow coal. 

I've built and tested with full GTNH 2.2.3