### PR TITLE
Fix for rain tank sky check

### DIFF
--- a/src/main/java/mods/railcraft/common/blocks/machine/alpha/TileTankWater.java
+++ b/src/main/java/mods/railcraft/common/blocks/machine/alpha/TileTankWater.java
@@ -177,11 +177,14 @@ public class TileTankWater extends TileTank implements ISidedInventory {
                     //                    String debug = "Biome=" + biome.biomeName + ", Humidity=" + humidity;
 
                     boolean outside = false;
+                    outer:
                     for (int x = xCoord - 1; x <= xCoord + 1; x++) {
                         for (int z = zCoord - 1; z <= zCoord + 1; z++) {
-                            outside = worldObj.canBlockSeeTheSky(x, yCoord + 3, z);
                             //                            System.out.println(x + ", " + (yCoord + 3) + ", " + z);
-                            if (outside) break;
+                            if (worldObj.canBlockSeeTheSky(x, yCoord + 3, z)) {
+                                outside = true;
+                                break outer;
+                            }
                         }
                     }
 


### PR DESCRIPTION
The check was previously breaking only the inner `for`-loop, allowing the value of `outside` to be rewritten to `false` by a later iteration of the outer `for`-loop.