### PR TITLE
Remove 8 tracks -> 1 standard rail recipe

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -6,7 +6,7 @@ dependencies {
     compile 'thaumcraft:Thaumcraft:1.7.10-4.2.3.5:dev'
     compile 'curse.maven:cofh-lib-220333:2388748'
 
-    compileOnly 'com.github.GTNewHorizons:ForestryMC:4.4.14:dev'
+    compileOnly 'com.github.GTNewHorizons:ForestryMC:4.6.7:dev'
     compileOnly 'curse.maven:craftguide-75557:2459320'
 
     runtimeOnly 'com.github.GTNewHorizons:Baubles:1.0.1.14:dev'

--- a/src/main/java/mods/railcraft/common/modules/ModuleCore.java
+++ b/src/main/java/mods/railcraft/common/modules/ModuleCore.java
@@ -308,17 +308,6 @@ public class ModuleCore extends RailcraftModule {
                     woodRailbed,
                     't',
                     new ItemStack(Blocks.redstone_torch));
-
-            CraftingPlugin.addShapelessRecipe(
-                    RailcraftItem.rail.getStack(1, EnumRail.STANDARD),
-                    Blocks.rail,
-                    Blocks.rail,
-                    Blocks.rail,
-                    Blocks.rail,
-                    Blocks.rail,
-                    Blocks.rail,
-                    Blocks.rail,
-                    Blocks.rail);
         }
 
         MachineTileRegistery.registerTileEntities();


### PR DESCRIPTION
Addressing this issue:
https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/9730

Also updated Forestry dependency to latest release (was broken)
