### PR TITLE
Fluids entering iron tanks use fallback texture when flowing texture is missing

### DIFF
--- a/src/main/java/mods/railcraft/client/render/FluidRenderer.java
+++ b/src/main/java/mods/railcraft/client/render/FluidRenderer.java
@@ -51,8 +51,7 @@ public class FluidRenderer {
         if (fluid == null) return null;
 
         IIcon side = RenderTools.getSafeIcon(fluid.getFlowingIcon());
-        if (fluid.getStillIcon() != null && fluid.getFlowingIcon() == null) {
-            // If still icon is present but flowing is missing, use still in place of flowing to avoid missing texture
+        if ((fluid.getStillIcon() != null) && (fluid.getFlowingIcon() == null)) {
             side = RenderTools.getSafeIcon(fluid.getStillIcon());
         }
 

--- a/src/main/java/mods/railcraft/client/render/FluidRenderer.java
+++ b/src/main/java/mods/railcraft/client/render/FluidRenderer.java
@@ -49,8 +49,14 @@ public class FluidRenderer {
 
     public static ResourceLocation setupFlowingLiquidTexture(Fluid fluid, IIcon[] texArray) {
         if (fluid == null) return null;
-        IIcon top = RenderTools.getSafeIcon(fluid.getStillIcon());
+
         IIcon side = RenderTools.getSafeIcon(fluid.getFlowingIcon());
+        if (fluid.getStillIcon() != null && fluid.getFlowingIcon() == null) {
+            // If still icon is present but flowing is missing, use still in place of flowing to avoid missing texture
+            side = RenderTools.getSafeIcon(fluid.getStillIcon());
+        }
+
+        IIcon top = RenderTools.getSafeIcon(fluid.getStillIcon());
         texArray[0] = top;
         texArray[1] = top;
         texArray[2] = side;


### PR DESCRIPTION
Fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/15017.

Instead of using the missing texture when the flowing texture is missing, the fluid's still texture is used which should always be available.

(First-time Java contribution, please be gentle :)

Left: Fluid with missing flowing texture (sulfuric acid); fluid entering tank uses still texture.
Right: Fluid with existing flowing texture (water); fluid uses animated flowing texture. 
![image](https://github.com/GTNewHorizons/Railcraft/assets/45722355/4aed679d-6319-49e2-80f6-c1b3b4d42c6c)
