### PR TITLE
Fix Railcraft tanks showing wrong texture after a resource reload

### DIFF
--- a/src/main/java/mods/railcraft/client/core/ClientProxy.java
+++ b/src/main/java/mods/railcraft/client/core/ClientProxy.java
@@ -24,6 +24,7 @@ import cpw.mods.fml.common.eventhandler.SubscribeEvent;
 import cpw.mods.fml.common.registry.VillagerRegistry;
 import mods.railcraft.api.carts.locomotive.LocomotiveRenderType;
 import mods.railcraft.client.render.BlockRenderer;
+import mods.railcraft.client.render.FluidRenderer;
 import mods.railcraft.client.render.RenderBlockFrame;
 import mods.railcraft.client.render.RenderBlockLamp;
 import mods.railcraft.client.render.RenderBlockMachineBeta;
@@ -123,6 +124,7 @@ public class ClientProxy extends CommonProxy {
     public void preInitClient() {
         MinecraftForge.EVENT_BUS.register(RCSoundHandler.INSTANCE);
         MinecraftForge.EVENT_BUS.register(new TextureHook());
+        MinecraftForge.EVENT_BUS.register(new FluidRenderer.TextureHook());
     }
 
     public static class TextureHook {

--- a/src/main/java/mods/railcraft/client/render/FluidRenderer.java
+++ b/src/main/java/mods/railcraft/client/render/FluidRenderer.java
@@ -13,10 +13,12 @@ import net.minecraft.client.renderer.texture.TextureMap;
 import net.minecraft.init.Blocks;
 import net.minecraft.util.IIcon;
 import net.minecraft.util.ResourceLocation;
+import net.minecraftforge.client.event.TextureStitchEvent;
 import net.minecraftforge.fluids.Fluid;
 
 import org.lwjgl.opengl.GL11;
 
+import cpw.mods.fml.common.eventhandler.SubscribeEvent;
 import mods.railcraft.client.render.RenderFakeBlock.RenderInfo;
 import mods.railcraft.common.fluids.tanks.StandardTank;
 
@@ -121,5 +123,16 @@ public class FluidRenderer {
         cache.put(fluid, diplayLists);
 
         return diplayLists;
+    }
+
+    public static class TextureHook {
+
+        @SubscribeEvent
+        public void clearRenderCaches(TextureStitchEvent.Post event) {
+            if (event.map.getTextureType() == 0) {
+                flowingRenderCache.clear();
+                stillRenderCache.clear();
+            }
+        }
     }
 }


### PR DESCRIPTION
Example of glitch:
![image](https://github.com/GTNewHorizons/Railcraft/assets/3904250/072e0d82-26f0-492d-b38b-1f2f732f2d11)
(That's supposed to be steam)