### PR TITLE
Use a hand-harvestable material for Railcraft machines to reflect their harvesting behavior

### DIFF
--- a/src/main/java/mods/railcraft/common/blocks/machine/BlockMachine.java
+++ b/src/main/java/mods/railcraft/common/blocks/machine/BlockMachine.java
@@ -48,7 +48,7 @@ public class BlockMachine extends BlockContainer implements IPostConnection {
     private final int[] metaOpacity;
 
     public BlockMachine(int renderId, IMachineProxy proxy, boolean opaque, int[] metaOpacity) {
-        super(Material.rock);
+        super(Material.ground);
         setResistance(4.5F);
         setHardness(2.0F);
         setStepSound(soundTypeStone);


### PR DESCRIPTION
The main purpose of this PR is to align Railcraft machine's advertised harvesting behavior with their actual behavior.

Side effects of the change: The blocks are faster to hand mine. I think this is an acceptable side effect as people will still want to use the tool to speed up. As a perk coke ovens won't be needlessly punishing to reposition anymore.

### Scope
This change applies to all Railcraft machine blocks. That means:
- [Advanced] Coke Oven
- Steam Oven
- Water Tank
- Liquid/Solid Fuel Boilers
- Iron/Steel/... Tanks
- World/Personal/Passive Anchors
- ...

### Alternative fix
We could instead make it so we only drop the blocks with tools. It would be painful in GTNH for new players making and learning to use Coke Ovens before they get an iron pickaxe.

### Before
![before](https://github.com/user-attachments/assets/9af269e0-dd85-4d32-a74e-d838d2bb01fb)

### After
![after](https://github.com/user-attachments/assets/df47cab3-0eda-4161-b283-c4b8950c4bb7)


### Motivation
Motivated by this questbook warning I want to remove:
![image](https://github.com/user-attachments/assets/cb5d7b25-5863-4127-87e8-2641092045b2)

And some old reported issues:
https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/2618
https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/3360
