### PR TITLE
Add Localizations

### DIFF
--- a/src/main/resources/assets/railcraft/lang/en_US.lang
+++ b/src/main/resources/assets/railcraft/lang/en_US.lang
@@ -213,9 +213,11 @@ item.railcraft.nugget.steel.name=Steel Nugget
 item.railcraft.nugget.tin.name=Tin Nugget
 
 item.railcraft.part.bleached.clay.name=Bleached Clay
+item.railcraft.part.circuit.name=Circuit
 item.railcraft.part.circuit.controller.name=Controller Circuit
 item.railcraft.part.circuit.receiver.name=Receiver Circuit
 item.railcraft.part.circuit.signal.name=Signal Circuit
+item.railcraft.part.gear.name=Gear
 item.railcraft.part.gear.bushing.name=Tin Gear Bushing
 item.railcraft.part.gear.gold.plate.name=Gold-Plate Gear
 item.railcraft.part.gear.iron.name=Iron Gear
@@ -225,16 +227,19 @@ item.railcraft.part.plate.iron.name=Iron Plate
 item.railcraft.part.plate.lead.name=Lead Plate
 item.railcraft.part.plate.steel.name=Steel Plate
 item.railcraft.part.plate.tin.name=Tin Plate
+item.railcraft.part.rail.name=Rail
 item.railcraft.part.rail.advanced.name=Advanced Rail
 item.railcraft.part.rail.electric.name=Electric Rail
 item.railcraft.part.rail.reinforced.name=Reinforced Rail
 item.railcraft.part.rail.speed.name=H.S. Rail
 item.railcraft.part.rail.standard.name=Standard Rail
 item.railcraft.part.rail.wood.name=Wooden Rail
+item.railcraft.part.railbed.name=Railbed
 item.railcraft.part.railbed.stone.name=Stone Railbed
 item.railcraft.part.railbed.wood.name=Wooden Railbed
 item.railcraft.part.rebar.name=Rebar
 item.railcraft.part.signal.lamp.name=Signal Lamp
+item.railcraft.part.tie.name=Tie
 item.railcraft.part.tie.stone.name=Stone Tie
 item.railcraft.part.tie.wood.name=Wooden Tie
 item.railcraft.part.turbine.blade.name=Turbine Blade
@@ -631,10 +636,12 @@ tile.detectorRail.name=Detector Track
 tile.goldenRail.name=Booster Track
 tile.rail.name=Track
 
+tile.railcraft.anvil.name=Steel Anvil
 tile.railcraft.anvil.intact.name=Steel Anvil
 tile.railcraft.anvil.slightlyDamaged.name=Slightly Damaged Steel Anvil
 tile.railcraft.anvil.veryDamaged.name=Very Damaged Steel Anvil
 
+tile.railcraft.brick.abyssal.name=Abyssal Block
 tile.railcraft.brick.abyssal.block.name=Abyssal Block
 tile.railcraft.brick.abyssal.brick.name=Abyssal Brick
 tile.railcraft.brick.abyssal.cobble.name=Abyssal Cobblestone
@@ -642,6 +649,7 @@ tile.railcraft.brick.abyssal.etched.name=Etched Abyssal Stone
 tile.railcraft.brick.abyssal.fitted.name=Fitted Abyssal Stone
 tile.railcraft.brick.abyssal.ornate.name=Ornate Abyssal Stone
 
+tile.railcraft.brick.bleachedbone.name=Bleached Bone Block
 tile.railcraft.brick.bleachedbone.block.name=Bleached Bone Block
 tile.railcraft.brick.bleachedbone.brick.name=Bleached Bone Brick
 tile.railcraft.brick.bleachedbone.cobble.name=Bleached Bone Cobblestone
@@ -649,6 +657,7 @@ tile.railcraft.brick.bleachedbone.etched.name=Etched Bleached Bone Stone
 tile.railcraft.brick.bleachedbone.fitted.name=Fitted Bleached Bone Stone
 tile.railcraft.brick.bleachedbone.ornate.name=Ornate Bleached Bone Stone
 
+tile.railcraft.brick.bloodstained.name=Blood Stained Block
 tile.railcraft.brick.bloodstained.block.name=Blood Stained Block
 tile.railcraft.brick.bloodstained.brick.name=Blood Stained Brick
 tile.railcraft.brick.bloodstained.cobble.name=Blood Stained Cobblestone
@@ -656,6 +665,7 @@ tile.railcraft.brick.bloodstained.etched.name=Etched Blood Stained Stone
 tile.railcraft.brick.bloodstained.fitted.name=Fitted Blood Stained Stone
 tile.railcraft.brick.bloodstained.ornate.name=Ornate Blood Stained Stone
 
+tile.railcraft.brick.frostbound.name=Frost Bound Block
 tile.railcraft.brick.frostbound.block.name=Frost Bound Block
 tile.railcraft.brick.frostbound.brick.name=Frost Bound Brick
 tile.railcraft.brick.frostbound.cobble.name=Frost Bound Cobblestone
@@ -663,6 +673,7 @@ tile.railcraft.brick.frostbound.etched.name=Etched Frost Bound Stone
 tile.railcraft.brick.frostbound.fitted.name=Fitted Frost Bound Stone
 tile.railcraft.brick.frostbound.ornate.name=Ornate Frost Bound Stone
 
+tile.railcraft.brick.infernal.name=Infernal Block
 tile.railcraft.brick.infernal.block.name=Infernal Block
 tile.railcraft.brick.infernal.brick.name=Infernal Brick
 tile.railcraft.brick.infernal.cobble.name=Infernal Cobblestone
@@ -670,12 +681,14 @@ tile.railcraft.brick.infernal.etched.name=Etched Infernal Stone
 tile.railcraft.brick.infernal.fitted.name=Fitted Infernal Stone
 tile.railcraft.brick.infernal.ornate.name=Ornate Infernal Stone
 
+tile.railcraft.brick.nether.name=Nether Block
 tile.railcraft.brick.nether.block.name=Nether Block
 tile.railcraft.brick.nether.cobble.name=Nether Cobblestone
 tile.railcraft.brick.nether.etched.name=Etched Nether Stone
 tile.railcraft.brick.nether.fitted.name=Fitted Nether Stone
 tile.railcraft.brick.nether.ornate.name=Ornate Nether Stone
 
+tile.railcraft.brick.quarried.name=Quarried Block
 tile.railcraft.brick.quarried.block.name=Quarried Block
 tile.railcraft.brick.quarried.brick.name=Quarried Brick
 tile.railcraft.brick.quarried.cobble.name=Quarried Cobblestone
@@ -683,6 +696,7 @@ tile.railcraft.brick.quarried.etched.name=Etched Quarried Stone
 tile.railcraft.brick.quarried.fitted.name=Fitted Quarried Stone
 tile.railcraft.brick.quarried.ornate.name=Ornate Quarried Stone
 
+tile.railcraft.brick.sandy.name=Sandy Block
 tile.railcraft.brick.sandy.block.name=Sandy Block
 tile.railcraft.brick.sandy.brick.name=Sandy Brick
 tile.railcraft.brick.sandy.cobble.name=Sandy Cobblestone
@@ -690,6 +704,7 @@ tile.railcraft.brick.sandy.etched.name=Etched Sandy Stone
 tile.railcraft.brick.sandy.fitted.name=Fitted Sandy Stone
 tile.railcraft.brick.sandy.ornate.name=Ornate Sandy Stone
 
+tile.railcraft.cube.name=Block
 tile.railcraft.cube.brick.infernal.name=Infernal Brick (Obsolete)
 tile.railcraft.cube.brick.sandy.name=Sandy Brick (Obsolete)
 tile.railcraft.cube.coke.name=Block of Coal Coke
@@ -705,6 +720,7 @@ tile.railcraft.cube.stone.abyssal.name=Abyssal Stone
 tile.railcraft.cube.stone.quarried.name=Quarried Stone
 tile.railcraft.cube.tin.name=Block of Tin
 
+tile.railcraft.detector.name=Detector
 tile.railcraft.detector.advanced.name=Detector - Advanced
 tile.railcraft.detector.age.name=Detector - Age
 tile.railcraft.detector.animal.name=Detector - Animal
@@ -734,6 +750,7 @@ tile.railcraft.frame.tip=Use to place Track on Shunting Wire
 
 tile.railcraft.glass.name=Strengthened Glass
 
+tile.railcraft.machine.alpha.name=Machine
 tile.railcraft.machine.alpha.anchor.admin.name=Admin Anchor
 tile.railcraft.machine.alpha.anchor.passive.name=Passive Anchor
 tile.railcraft.machine.alpha.anchor.personal.name=Personal Anchor
@@ -757,6 +774,7 @@ tile.railcraft.machine.alpha.trade.station.name=Trade Station
 tile.railcraft.machine.alpha.turbine.name=Steam Turbine Housing
 tile.railcraft.machine.alpha.turbine.tip=Multi-Block: 3x2x2\n Generates Electricity from Steam\nOutputs water to the bottom\n Requires a Turbine Rotor
 
+tile.railcraft.machine.beta.name=Machine
 tile.railcraft.machine.beta.anchor.sentinel.name=Anchor Sentinel
 tile.railcraft.machine.beta.boiler.firebox.liquid.name=Liquid Fueled Boiler Firebox
 tile.railcraft.machine.beta.boiler.firebox.liquid.tip=Multi-Block: Variable Size, Bottom Layer\n Dimensions: 1x1, 2x2, 3x3
@@ -789,9 +807,11 @@ tile.railcraft.machine.beta.tank.steel.valve.tip=Multi-Block: Must be in bottom\
 tile.railcraft.machine.beta.tank.steel.wall.name=Steel Tank Wall
 tile.railcraft.machine.beta.tank.steel.wall.tip=Multi-Block: Variable Size, Hollow\n Heights: 4, 5, 6, 7, 8\n Diameters: 3, 5, 7, 9
 
+tile.railcraft.machine.delta.name=Electric Shunting Wire
 tile.railcraft.machine.delta.wire.name=Electric Shunting Wire
 tile.railcraft.machine.delta.wire.tip=Connect Electric Track across gaps\n Place under Track using Wire Support Frames
 
+tile.railcraft.machine.epsilon.name=Machine
 tile.railcraft.machine.epsilon.admin.steam.producer.name=Admin Steam Producer
 tile.railcraft.machine.epsilon.admin.steam.producer.tip=Provides Unlimited Steam
 tile.railcraft.machine.epsilon.electric.feeder.admin.name=Admin Feeder Unit
@@ -804,6 +824,7 @@ tile.railcraft.machine.epsilon.flux.transformer.tip=Multi-Block: 2x2x2\n Convert
 tile.railcraft.machine.epsilon.force.track.emitter.name=Force Track Emitter
 tile.railcraft.machine.epsilon.force.track.emitter.tip=Projects energy-based tracks
 
+tile.railcraft.machine.gamma.name=Machine
 tile.railcraft.machine.gamma.dispenser.cart.name=Cart Dispenser
 tile.railcraft.machine.gamma.dispenser.cart.tip=Dispenses Carts onto Tracks\n§o§9- Hit with Crowbar to change orientation -\n§o§c- Apply Redstone to dispense Cart -
 tile.railcraft.machine.gamma.dispenser.train.name=Train Dispenser
@@ -835,6 +856,7 @@ railcraft.gui.tank.titanium=Titanium Tank
 railcraft.gui.tank.tungstensteel=Tungstensteel Tank
 railcraft.gui.tank.palladium=Palladium Tank
 
+tile.railcraft.machine.zeta.name=Tank
 tile.railcraft.machine.zeta.tank.aluminium.gauge.name=Aluminium Tank Gauge
 tile.railcraft.machine.zeta.tank.aluminium.gauge.tip=Multi-Block: Variable Size, Hollow\n Heights: 4, 5, 6, 7, 8\n Diameters: 3, 5, 7, 9
 tile.railcraft.machine.zeta.tank.aluminium.valve.name=Aluminium Tank Valve
@@ -870,6 +892,7 @@ railcraft.gui.tank.iridium=Iridium Tank
 railcraft.gui.tank.osmium=Osmium Tank
 railcraft.gui.tank.neutronium=Neutronium Tank
 
+tile.railcraft.machine.eta.name=Tank
 tile.railcraft.machine.eta.tank.iridium.gauge.name=Iridium Tank Gauge
 tile.railcraft.machine.eta.tank.iridium.gauge.tip=Multi-Block: Variable Size, Hollow\n Heights: 4, 5, 6, 7, 8\n Diameters: 3, 5, 7, 9
 tile.railcraft.machine.eta.tank.iridium.valve.name=Iridium Tank Valve
@@ -889,6 +912,7 @@ tile.railcraft.machine.eta.tank.neutronium.valve.tip=Multi-Block: Must be in bot
 tile.railcraft.machine.eta.tank.neutronium.wall.name=Neutronium Tank Wall
 tile.railcraft.machine.eta.tank.neutronium.wall.tip=Multi-Block: Variable Size, Hollow\n Heights: 4, 5, 6, 7, 8\n Diameters: 3, 5, 7, 9
 
+tile.railcraft.ore.name=Ore
 tile.railcraft.ore.dark.diamond.name=Dark Diamond Ore
 tile.railcraft.ore.dark.emerald.name=Dark Emerald Ore
 tile.railcraft.ore.dark.lapis.name=Dark Lapis Lazuli Ore
@@ -903,6 +927,7 @@ tile.railcraft.ore.saltpeter.name=Saltpeter Ore
 tile.railcraft.ore.sulfur.name=Sulfur Ore
 
 tile.railcraft.post.emblem.name=Emblem Post
+tile.railcraft.post.metal.name=Metal Post
 tile.railcraft.post.metal.black.name=Black Metal Post
 tile.railcraft.post.metal.blue.name=Blue Metal Post
 tile.railcraft.post.metal.brown.name=Brown Metal Post
@@ -916,6 +941,7 @@ tile.railcraft.post.metal.magenta.name=Magenta Metal Post
 tile.railcraft.post.metal.unpainted.name=Metal Post
 tile.railcraft.post.metal.orange.name=Orange Metal Post
 tile.railcraft.post.metal.pink.name=Pink Metal Post
+tile.railcraft.post.metal.platform.name=Metal Platform
 tile.railcraft.post.metal.platform.black.name=Black Metal Platform
 tile.railcraft.post.metal.platform.blue.name=Blue Metal Platform
 tile.railcraft.post.metal.platform.brown.name=Brown Metal Platform
@@ -939,11 +965,13 @@ tile.railcraft.post.metal.white.name=White Metal Post
 tile.railcraft.post.metal.yellow.name=Yellow Metal Post
 tile.railcraft.post.stone.name=Stone Post
 tile.railcraft.post.stone.platform.name=Stone Platform
+tile.railcraft.post.name=Wooden Post
 tile.railcraft.post.wood.name=Wooden Post
 tile.railcraft.post.wood.platform.name=Wooden Platform
 
 tile.railcraft.residual.heat.name=Residual Heat
 
+tile.railcraft.signal.name=Signal
 tile.railcraft.signal.block.signal.dual.name=Dual-Head Block Signal
 tile.railcraft.signal.block.signal.dual.tip=Detects Carts in Signal Block\nDisplays aspect of linked Controller\n§o§9Aerial Linkages:\n§o§9- 1x Signal Blocks\n§o§9- 1x Controller\n§o§9- 1x Receiver\n§o§cRelevant Tools:\n§o§c- Signal Tuner\n§o§c- Signal Block Surveyor
 tile.railcraft.signal.block.signal.name=Block Signal
@@ -973,6 +1001,7 @@ tile.railcraft.signal.switch.motor.tip=Controls adjacent Switch Tracks\n§o§9Ae
 tile.railcraft.signal.switch.routing.name=Routing Switch Motor
 tile.railcraft.signal.switch.routing.tip=Controls adjacent Switch Tracks\n§o§9Scripted Logic Operation\n§o§cRelevant Tools:\n§o§c- Routing Table
 
+tile.railcraft.slab.name=Slab
 tile.railcraft.slab.abyssal.block.name=Abyssal Block Slab
 tile.railcraft.slab.abyssal.brick.name=Abyssal Brick Slab
 tile.railcraft.slab.abyssal.cobble.name=Abyssal Cobble Slab
@@ -1018,6 +1047,7 @@ tile.railcraft.slab.snow.name=Snow Slab
 tile.railcraft.slab.steel.name=Steel Slab
 tile.railcraft.slab.tin.name=Tin Slab
 
+tile.railcraft.stair.name=Stairs
 tile.railcraft.stair.abyssal.block.name=Abyssal Block Stairs
 tile.railcraft.stair.abyssal.brick.name=Abyssal Brick Stairs
 tile.railcraft.stair.abyssal.cobble.name=Abyssal Cobble Stairs
@@ -1063,6 +1093,7 @@ tile.railcraft.stair.snow.name=Snow Stairs
 tile.railcraft.stair.steel.name=Steel Stairs
 tile.railcraft.stair.tin.name=Tin Stairs
 
+tile.railcraft.lantern.metal.name=Lantern
 tile.railcraft.lantern.metal.copper.name=Copper Lantern
 tile.railcraft.lantern.metal.gold.name=Gold Lantern
 tile.railcraft.lantern.metal.iron.name=Iron Lantern
@@ -1070,6 +1101,7 @@ tile.railcraft.lantern.metal.lead.name=Lead Lantern
 tile.railcraft.lantern.metal.steel.name=Steel Lantern
 tile.railcraft.lantern.metal.tin.name=Tin Lantern
 
+tile.railcraft.lantern.stone.name=Stone Lantern
 tile.railcraft.lantern.stone.abyssal.name=Abyssal Stone Lantern
 tile.railcraft.lantern.stone.bleachedbone.name=Bleached Bone Stone Lantern
 tile.railcraft.lantern.stone.bloodstained.name=Blood Stained Stone Lantern
@@ -1081,6 +1113,7 @@ tile.railcraft.lantern.stone.sandstone.name=Sandstone Lantern
 tile.railcraft.lantern.stone.sandy.name=Sandy Stone Lantern
 tile.railcraft.lantern.stone.stone.name=Stone Lantern
 
+tile.railcraft.track.name=Track
 tile.railcraft.track.boarding.name=Boarding Track
 tile.railcraft.track.boarding.tip=Replaced by Locking Track
 tile.railcraft.track.boarding.train.name=Train Boarding Track
@@ -1178,6 +1211,8 @@ tile.railcraft.track.wye.tip=§o§c- Requires Switch Motor/Lever to switch -
 tile.railcraft.track.autolococoupler.name=Automatic Locomotive Coupler
 tile.railcraft.track.autolococoupler.tip=Sets Passing Locomotives To\nLink With First Cart They \nCollide With And Then Automatically\nSwitch To Shunting Speed.\n§o§c- Apply Redstone to enable -
 
+tile.railcraft.wall.alpha.name=Wall
+tile.railcraft.wall.beta.name=Wall
 tile.railcraft.wall.abyssal.brick.name=Abyssal Brick Wall
 tile.railcraft.wall.bleachedbone.brick.name=Bleached Bone Brick Wall
 tile.railcraft.wall.bloodstained.brick.name=Blood Stained Brick Wall


### PR DESCRIPTION
This adds some missing localizations for unlocalized names returned by the ItemStack-insensitive version of `Item.getUnlocalizedName()`.
Relevant for the Item/Block stats introduced in https://github.com/GTNewHorizons/Hodgepodge/pull/398.