### PR TITLE
Fix Water Tank string when using a Crafting Station

### DIFF
--- a/src/main/java/mods/railcraft/common/blocks/machine/alpha/TileTankWater.java
+++ b/src/main/java/mods/railcraft/common/blocks/machine/alpha/TileTankWater.java
@@ -93,7 +93,7 @@ public class TileTankWater extends TileTank implements ISidedInventory {
     private IInventory invOutput = new InventoryMapper(this, SLOT_OUTPUT, 1);
 
     public TileTankWater() {
-        super("gui.tank.water", 2, patterns);
+        super("railcraft.gui.tank.water", 2, patterns);
         tank = new FilteredTank(TANK_CAPACITY, Fluids.WATER.get(), this);
         tankManager.add(tank);
     }


### PR DESCRIPTION
When placing a Crafting Station next to a Water Tank, the string will not have localization (https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/19284)

This PR fixes the issue by changing the string that is asked by the Crafting Station (`getInventoryName()`) 

![railcraft_watertank](https://github.com/user-attachments/assets/4656e8a3-7eb3-476f-886e-93043412263a)
