### PR TITLE
Add goggle aura API

### DIFF
--- a/src/main/java/mods/railcraft/api/core/items/IToolGoggles.java
+++ b/src/main/java/mods/railcraft/api/core/items/IToolGoggles.java
@@ -1,8 +1,10 @@
 package mods.railcraft.api.core.items;
 
-import mods.railcraft.common.items.ItemGoggles.GoggleAura;
 import net.minecraft.item.ItemStack;
 
+import mods.railcraft.common.items.ItemGoggles.GoggleAura;
+
 public interface IToolGoggles {
+
     public GoggleAura getCurrentAura(ItemStack goggles);
 }

--- a/src/main/java/mods/railcraft/api/core/items/IToolGoggles.java
+++ b/src/main/java/mods/railcraft/api/core/items/IToolGoggles.java
@@ -1,10 +1,20 @@
 package mods.railcraft.api.core.items;
 
+import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
+import net.minecraft.world.World;
 
 import mods.railcraft.common.items.ItemGoggles.GoggleAura;
+import mods.railcraft.common.plugins.forge.ChatPlugin;
+import mods.railcraft.common.util.misc.Game;
 
 public interface IToolGoggles {
 
     public GoggleAura getCurrentAura(ItemStack goggles);
+
+    public static void displaySwitchMessage(World world, EntityPlayer player, GoggleAura newAura) {
+        if (Game.isNotHost(world)) {
+            ChatPlugin.sendLocalizedChat(player, "railcraft.gui.goggles.mode", "\u00A75" + newAura);
+        }
+    }
 }

--- a/src/main/java/mods/railcraft/api/core/items/IToolGoggles.java
+++ b/src/main/java/mods/railcraft/api/core/items/IToolGoggles.java
@@ -1,0 +1,8 @@
+package mods.railcraft.api.core.items;
+
+import mods.railcraft.common.items.ItemGoggles.GoggleAura;
+import net.minecraft.item.ItemStack;
+
+public interface IToolGoggles {
+    public GoggleAura getCurrentAura(ItemStack goggles);
+}

--- a/src/main/java/mods/railcraft/client/util/effects/ClientEffectProxy.java
+++ b/src/main/java/mods/railcraft/client/util/effects/ClientEffectProxy.java
@@ -18,6 +18,7 @@ import net.minecraft.world.World;
 
 import cpw.mods.fml.client.FMLClientHandler;
 import mods.railcraft.api.core.WorldCoordinate;
+import mods.railcraft.api.core.items.IToolGoggles;
 import mods.railcraft.api.signals.SignalTools;
 import mods.railcraft.client.core.AuraKeyHandler;
 import mods.railcraft.client.particles.EntityChimneyFX;
@@ -28,7 +29,6 @@ import mods.railcraft.client.particles.EntityHeatTrailFX;
 import mods.railcraft.client.particles.EntitySteamFX;
 import mods.railcraft.client.particles.EntityTuningFX;
 import mods.railcraft.client.render.RenderTESRSignals;
-import mods.railcraft.common.items.ItemGoggles;
 import mods.railcraft.common.items.ItemGoggles.GoggleAura;
 import mods.railcraft.common.util.effects.CommonEffectProxy;
 import mods.railcraft.common.util.effects.EffectManager;
@@ -101,10 +101,10 @@ public class ClientEffectProxy extends CommonEffectProxy {
 
     @Override
     public boolean isGoggleAuraActive(GoggleAura aura) {
-        if (ItemGoggles.areEnabled()) {
-            ItemStack goggles = ItemGoggles.getGoggles(Minecraft.getMinecraft().thePlayer);
-            return ItemGoggles.getCurrentAura(goggles) == aura;
-        }
+        ItemStack helm = Minecraft.getMinecraft().thePlayer.getCurrentArmor(MiscTools.ArmorSlots.HELM.ordinal());
+        if (helm != null && helm.getItem() instanceof IToolGoggles) {
+            return ((IToolGoggles)helm.getItem()).getCurrentAura(helm) == aura;
+        };
         return AuraKeyHandler.isAuraEnabled(aura);
     }
 

--- a/src/main/java/mods/railcraft/client/util/effects/ClientEffectProxy.java
+++ b/src/main/java/mods/railcraft/client/util/effects/ClientEffectProxy.java
@@ -103,8 +103,8 @@ public class ClientEffectProxy extends CommonEffectProxy {
     public boolean isGoggleAuraActive(GoggleAura aura) {
         ItemStack helm = Minecraft.getMinecraft().thePlayer.getCurrentArmor(MiscTools.ArmorSlots.HELM.ordinal());
         if (helm != null && helm.getItem() instanceof IToolGoggles) {
-            return ((IToolGoggles)helm.getItem()).getCurrentAura(helm) == aura;
-        };
+            return ((IToolGoggles) helm.getItem()).getCurrentAura(helm) == aura;
+        } ;
         return AuraKeyHandler.isAuraEnabled(aura);
     }
 

--- a/src/main/java/mods/railcraft/common/items/ItemGoggles.java
+++ b/src/main/java/mods/railcraft/common/items/ItemGoggles.java
@@ -17,6 +17,7 @@ import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.world.World;
 
 import cpw.mods.fml.common.FMLCommonHandler;
+import mods.railcraft.api.core.items.IToolGoggles;
 import mods.railcraft.common.blocks.hidden.BlockHidden;
 import mods.railcraft.common.blocks.hidden.TrailTicker;
 import mods.railcraft.common.core.RailcraftConfig;
@@ -34,7 +35,7 @@ import mods.railcraft.common.util.misc.MiscTools;
 /**
  * @author CovertJaguar <http://www.railcraft.info>
  */
-public class ItemGoggles extends ItemArmor {
+public class ItemGoggles extends ItemArmor implements IToolGoggles {
 
     private static final String TEXTURE = RailcraftConstants.ARMOR_TEXTURE_FOLDER + "goggles.png";
     private static ItemGoggles item;
@@ -83,7 +84,8 @@ public class ItemGoggles extends ItemArmor {
         return new ItemStack(item);
     }
 
-    public static GoggleAura getCurrentAura(ItemStack goggles) {
+    @Override
+    public GoggleAura getCurrentAura(ItemStack goggles) {
         GoggleAura aura = GoggleAura.NONE;
         if (goggles != null && goggles.getItem() instanceof ItemGoggles) {
             NBTTagCompound data = goggles.getTagCompound();
@@ -92,7 +94,7 @@ public class ItemGoggles extends ItemArmor {
         return aura;
     }
 
-    public static void incrementAura(ItemStack goggles) {
+    public void incrementAura(ItemStack goggles) {
         if (goggles != null && goggles.getItem() instanceof ItemGoggles) {
             NBTTagCompound data = goggles.getTagCompound();
             if (data == null) {
@@ -111,13 +113,6 @@ public class ItemGoggles extends ItemArmor {
 
     public static boolean areEnabled() {
         return item != null;
-    }
-
-    public static ItemStack getGoggles(EntityPlayer player) {
-        if (player == null) return null;
-        ItemStack helm = player.getCurrentArmor(MiscTools.ArmorSlots.HELM.ordinal());
-        if (helm != null && helm.getItem() instanceof ItemGoggles) return helm;
-        return null;
     }
 
     public static boolean isPlayerWearing(EntityPlayer player) {

--- a/src/main/java/mods/railcraft/common/items/ItemGoggles.java
+++ b/src/main/java/mods/railcraft/common/items/ItemGoggles.java
@@ -22,14 +22,12 @@ import mods.railcraft.common.blocks.hidden.BlockHidden;
 import mods.railcraft.common.blocks.hidden.TrailTicker;
 import mods.railcraft.common.core.RailcraftConfig;
 import mods.railcraft.common.core.RailcraftConstants;
-import mods.railcraft.common.plugins.forge.ChatPlugin;
 import mods.railcraft.common.plugins.forge.CraftingPlugin;
 import mods.railcraft.common.plugins.forge.CreativePlugin;
 import mods.railcraft.common.plugins.forge.LocalizationPlugin;
 import mods.railcraft.common.plugins.forge.LootPlugin;
 import mods.railcraft.common.plugins.forge.OreDictPlugin;
 import mods.railcraft.common.plugins.forge.RailcraftRegistry;
-import mods.railcraft.common.util.misc.Game;
 import mods.railcraft.common.util.misc.MiscTools;
 
 /**
@@ -128,10 +126,7 @@ public class ItemGoggles extends ItemArmor implements IToolGoggles {
     @Override
     public ItemStack onItemRightClick(ItemStack stack, World world, EntityPlayer player) {
         incrementAura(stack);
-        if (Game.isNotHost(world)) {
-            GoggleAura aura = getCurrentAura(stack);
-            ChatPlugin.sendLocalizedChat(player, "railcraft.gui.goggles.mode", "\u00A75" + aura);
-        }
+        IToolGoggles.displaySwitchMessage(world, player, getCurrentAura(stack));
         return stack.copy();
     }
 


### PR DESCRIPTION
Should just be a single function any headpiece armor can implement to display the aura particles.

This should be reviewed/tested as I'm unsure how the server/client split works here and this is my first "big change", but I tested this locally by adding it to the Forestry spectacles (returning the anchor aura on them) and it worked wonderfully.

Limitations of this now are that Railcraft itself only checks the helmet slot, so this interface only works for helmet type armor/items (should work for a pumpkin, anything that can go into the helmet slot really)

This would enable adding a Nano/Quantum suit version of the Trackman's goggles, or an upgrade for the Ender IO armor.

Right now, changing the aura is managed by the item itself, but I'd think that could be included into the API later too.