### PR TITLE
Fix railcraft help command

### DIFF
--- a/src/main/java/mods/railcraft/common/commands/CommandHelpers.java
+++ b/src/main/java/mods/railcraft/common/commands/CommandHelpers.java
@@ -78,7 +78,7 @@ public class CommandHelpers {
     }
 
     public static void processChildCommand(ICommandSender sender, SubCommand child, String[] args) {
-        if (!sender.canCommandSenderUseCommand(child.getRequiredPermissionLevel(), child.getFullCommandString()))
+        if (!sender.canCommandSenderUseCommand(child.getPermissionLevel(), child.getFullCommandString()))
             throw new WrongUsageException(LocalizationPlugin.translate("command.railcraft.noperms"));
         String[] newargs = new String[args.length - 1];
         System.arraycopy(args, 1, newargs, 0, newargs.length);
@@ -100,7 +100,7 @@ public class CommandHelpers {
                 body,
                 "command.railcraft.aliases",
                 command.getCommandAliases().toString().replace("[", "").replace("]", ""));
-        sendLocalizedChatMessage(sender, body, "command.railcraft.permlevel", command.getRequiredPermissionLevel());
+        sendLocalizedChatMessage(sender, body, "command.railcraft.permlevel", command.getPermissionLevel());
         sendLocalizedChatMessage(
                 sender,
                 body,

--- a/src/main/java/mods/railcraft/common/commands/IModCommand.java
+++ b/src/main/java/mods/railcraft/common/commands/IModCommand.java
@@ -22,7 +22,7 @@ public interface IModCommand extends ICommand {
     @Override
     List<String> getCommandAliases();
 
-    int getRequiredPermissionLevel();
+    int getPermissionLevel();
 
     SortedSet<SubCommand> getChildren();
 

--- a/src/main/java/mods/railcraft/common/commands/RootCommand.java
+++ b/src/main/java/mods/railcraft/common/commands/RootCommand.java
@@ -44,7 +44,12 @@ public class RootCommand extends CommandBase implements IModCommand {
     }
 
     @Override
-    public int getRequiredPermissionLevel() {
+    public final int getRequiredPermissionLevel() {
+        return getPermissionLevel();
+    }
+
+    @Override
+    public int getPermissionLevel() {
         return 0;
     }
 

--- a/src/main/java/mods/railcraft/common/commands/SubCommand.java
+++ b/src/main/java/mods/railcraft/common/commands/SubCommand.java
@@ -97,13 +97,13 @@ public abstract class SubCommand implements IModCommand {
     }
 
     @Override
-    public final int getRequiredPermissionLevel() {
+    public final int getPermissionLevel() {
         return permLevel.permLevel;
     }
 
     @Override
     public boolean canCommandSenderUseCommand(ICommandSender sender) {
-        return sender.canCommandSenderUseCommand(getRequiredPermissionLevel(), getCommandName());
+        return sender.canCommandSenderUseCommand(getPermissionLevel(), getCommandName());
     }
 
     @Override


### PR DESCRIPTION
Closes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/18320

Issue was caused by the railcraft `IModCommand` interface having a method with the same name as the minecraft `CommandBase` class with MCP, leading to reobfuscation causing issues