### PR TITLE
add support for IronTank upgrades

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -8,7 +8,7 @@ dependencies {
     compileOnly("com.github.GTNewHorizons:ForestryMC:4.10.5:dev") { transitive = false }
     compileOnly("curse.maven:craftguide-75557:2459320")
     compileOnly("com.github.GTNewHorizons:Mobs-Info:0.5.2-GTNH:dev")
-    compileOnly('com.github.GTNewHorizons:GT5-Unofficial:5.09.51.230:dev') {
+    compileOnly('com.github.GTNewHorizons:GT5-Unofficial:5.09.51.234:dev') {
         exclude group: 'com.github.GTNewHorizons', module: 'Railcraft'
     }
 

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -11,6 +11,10 @@ dependencies {
     compileOnly('com.github.GTNewHorizons:GT5-Unofficial:5.09.51.234:dev') {
         exclude group: 'com.github.GTNewHorizons', module: 'Railcraft'
     }
+    compileOnly("com.github.GTNewHorizons:Irontanks:1.4.1:dev");
+    compileOnly("secondderivative.irontankminecarts:IronTankMinecarts:1.0.4:dev") {
+        exclude group: 'com.github.GTNewHorizons', module: 'Railcraft'
+    }
 
     runtimeOnly("com.github.GTNewHorizons:Baubles:1.0.4:dev") // for Thaumcraft
     runtimeOnlyNonPublishable("com.github.GTNewHorizons:NotEnoughItems:2.7.38-GTNH:dev")

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -12,7 +12,7 @@ dependencies {
         exclude group: 'com.github.GTNewHorizons', module: 'Railcraft'
     }
     compileOnly("com.github.GTNewHorizons:Irontanks:1.4.1:dev");
-    compileOnly("secondderivative.irontankminecarts:IronTankMinecarts:1.0.4:dev") {
+    compileOnly("secondderivative.irontankminecarts:IronTankMinecarts:1.0.5:dev") {
         exclude group: 'com.github.GTNewHorizons', module: 'Railcraft'
     }
     

--- a/src/main/java/mods/railcraft/common/carts/EntityCartTank.java
+++ b/src/main/java/mods/railcraft/common/carts/EntityCartTank.java
@@ -21,10 +21,9 @@ import net.minecraftforge.fluids.IFluidHandler;
 
 import com.indemnity83.irontank.item.ItemTankChanger;
 import com.indemnity83.irontank.reference.TankType;
-import com.indemnity83.irontank.reference.TankType;
 
+import cpw.mods.fml.common.Loader;
 import cpw.mods.fml.common.Optional;
-
 import mods.railcraft.api.carts.IFluidCart;
 import mods.railcraft.api.carts.ILiquidTransfer;
 import mods.railcraft.common.core.RailcraftConfig;
@@ -177,20 +176,7 @@ public class EntityCartTank extends EntityCartFiltered
             ItemStack stack = player.getCurrentEquippedItem();
             if (stack != null && stack.getItem() instanceof ItemTankChanger changer) {
                 if (changer.type.canUpgrade(tankType())) {
-                    if (Game.isHost(worldObj)) {
-                        TankType newType = changer.type.target;
-                        NBTTagCompound nbt = new NBTTagCompound();
-                        writeToNBT(nbt);
-                        setDead();
-                        try {
-                            EntityMinecartTankAbstract minecart = EntityMinecartTankAbstract.map.get(newType)
-                                    .getConstructor(World.class).newInstance(worldObj);
-                            minecart.readFromNBT(nbt);
-                            worldObj.spawnEntityInWorld(minecart);
-                        } catch (Exception e) {
-                            e.printStackTrace();
-                        }
-                    }
+                    tryUpgrade(changer);
                     if (!player.capabilities.isCreativeMode && --stack.stackSize <= 0) {
                         player.setCurrentItemOrArmor(0, null);
                     }
@@ -203,6 +189,24 @@ public class EntityCartTank extends EntityCartFiltered
             GuiHandler.openGui(EnumGui.CART_TANK, player, worldObj, this);
         }
         return true;
+    }
+
+    @Optional.Method(modid = "irontankminecarts")
+    private void tryUpgrade(ItemTankChanger changer) {
+        if (Game.isHost(worldObj)) {
+            TankType newType = changer.type.target;
+            NBTTagCompound nbt = new NBTTagCompound();
+            writeToNBT(nbt);
+            setDead();
+            try {
+                EntityMinecartTankAbstract minecart = EntityMinecartTankAbstract.map.get(newType)
+                        .getConstructor(World.class).newInstance(worldObj);
+                minecart.readFromNBT(nbt);
+                worldObj.spawnEntityInWorld(minecart);
+            } catch (Exception e) {
+                e.printStackTrace();
+            }
+        }
     }
 
     @Override

--- a/src/main/java/mods/railcraft/common/carts/EntityCartTank.java
+++ b/src/main/java/mods/railcraft/common/carts/EntityCartTank.java
@@ -372,9 +372,4 @@ public class EntityCartTank extends EntityCartFiltered
     public boolean canProvidePulledFluid(EntityMinecart requester, Fluid fluid) {
         return canPassFluidRequests(fluid);
     }
-
-    @Optional.Method(modid = "irontankminecarts")
-    public TankType tankType() {
-        return TankType.GLASS;
-    }
 }

--- a/src/main/java/mods/railcraft/common/carts/EntityCartTank.java
+++ b/src/main/java/mods/railcraft/common/carts/EntityCartTank.java
@@ -19,6 +19,10 @@ import net.minecraftforge.fluids.FluidStack;
 import net.minecraftforge.fluids.FluidTankInfo;
 import net.minecraftforge.fluids.IFluidHandler;
 
+import com.indemnity83.irontank.item.ItemTankChanger;
+import com.indemnity83.irontank.reference.TankType;
+
+import cpw.mods.fml.common.Loader;
 import mods.railcraft.api.carts.IFluidCart;
 import mods.railcraft.api.carts.ILiquidTransfer;
 import mods.railcraft.common.core.RailcraftConfig;
@@ -32,11 +36,6 @@ import mods.railcraft.common.util.inventory.InvTools;
 import mods.railcraft.common.util.inventory.wrappers.InventoryMapper;
 import mods.railcraft.common.util.misc.Game;
 import mods.railcraft.common.util.misc.MiscTools;
-
-import cpw.mods.fml.common.Loader;
-
-import com.indemnity83.irontank.item.ItemTankChanger;
-import com.indemnity83.irontank.reference.TankType;
 import secondderivative.irontankminecarts.minecarts.EntityMinecartTankAbstract;
 
 public class EntityCartTank extends EntityCartFiltered
@@ -175,7 +174,7 @@ public class EntityCartTank extends EntityCartFiltered
         if (Loader.isModLoaded("irontankminecarts")) {
             ItemStack stack = player.getCurrentEquippedItem();
             if (stack != null && stack.getItem() instanceof ItemTankChanger changer) {
-                if (changer.type.canUpgrade(TankType.GLASS)) {
+                if (changer.type.canUpgrade(tankType())) {
                     if (Game.isHost(worldObj)) {
                         TankType newType = changer.type.target;
                         NBTTagCompound nbt = new NBTTagCompound();
@@ -183,8 +182,7 @@ public class EntityCartTank extends EntityCartFiltered
                         setDead();
                         try {
                             EntityMinecartTankAbstract minecart = EntityMinecartTankAbstract.map.get(newType)
-                                .getConstructor(World.class)
-                                .newInstance(worldObj);
+                                    .getConstructor(World.class).newInstance(worldObj);
                             minecart.readFromNBT(nbt);
                             worldObj.spawnEntityInWorld(minecart);
                         } catch (Exception e) {
@@ -373,5 +371,10 @@ public class EntityCartTank extends EntityCartFiltered
     @Override
     public boolean canProvidePulledFluid(EntityMinecart requester, Fluid fluid) {
         return canPassFluidRequests(fluid);
+    }
+
+    @Optional.Method(modid = "irontankminecarts")
+    public TankType tankType() {
+        return TankType.GLASS;
     }
 }


### PR DESCRIPTION
Requires a release of https://github.com/GTNewHorizons/Irontanks/pull/14 to 1.4.1

as well as a new release of https://github.com/2ndDerivative/IronTankMinecarts/pull/2

and so by extension https://github.com/GTNewHorizons/Railcraft/pull/84