### PR TITLE
Add superclass function for IronTanks tank type

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -11,6 +11,7 @@ dependencies {
     compileOnly('com.github.GTNewHorizons:GT5-Unofficial:5.09.51.234:dev') {
         exclude group: 'com.github.GTNewHorizons', module: 'Railcraft'
     }
+    compileOnly('com.github.GTNewHorizons:Irontanks:1.4.0:dev');
 
     runtimeOnly("com.github.GTNewHorizons:Baubles:1.0.4:dev") // for Thaumcraft
     runtimeOnlyNonPublishable("com.github.GTNewHorizons:NotEnoughItems:2.7.38-GTNH:dev")

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -11,7 +11,7 @@ dependencies {
     compileOnly('com.github.GTNewHorizons:GT5-Unofficial:5.09.51.234:dev') {
         exclude group: 'com.github.GTNewHorizons', module: 'Railcraft'
     }
-    compileOnly('com.github.GTNewHorizons:Irontanks:1.4.0:dev');
+    compileOnly('com.github.GTNewHorizons:Irontanks:1.4.1:dev');
 
     runtimeOnly("com.github.GTNewHorizons:Baubles:1.0.4:dev") // for Thaumcraft
     runtimeOnlyNonPublishable("com.github.GTNewHorizons:NotEnoughItems:2.7.38-GTNH:dev")

--- a/src/main/java/mods/railcraft/common/carts/EntityCartTank.java
+++ b/src/main/java/mods/railcraft/common/carts/EntityCartTank.java
@@ -19,6 +19,9 @@ import net.minecraftforge.fluids.FluidStack;
 import net.minecraftforge.fluids.FluidTankInfo;
 import net.minecraftforge.fluids.IFluidHandler;
 
+import com.indemnity83.irontank.reference.TankType;
+
+import cpw.mods.fml.common.Optional;
 import mods.railcraft.api.carts.IFluidCart;
 import mods.railcraft.api.carts.ILiquidTransfer;
 import mods.railcraft.common.core.RailcraftConfig;
@@ -340,5 +343,10 @@ public class EntityCartTank extends EntityCartFiltered
     @Override
     public boolean canProvidePulledFluid(EntityMinecart requester, Fluid fluid) {
         return canPassFluidRequests(fluid);
+    }
+
+    @Optional.Method(modid = "irontankminecarts")
+    public TankType tankType() {
+        return TankType.GLASS;
     }
 }


### PR DESCRIPTION
This is just a marker function to avoid a circular PR dependency

as the tank minecarts are all subclasses of the CartTank class, and nobody upgrades *into* a CartTank class, this can be used to mark all the Iron Tank carts by overriding, so we only have the upgrade logic in the superclass.