### PR TITLE
Render gases in tanks by transparency instead of level

### DIFF
--- a/src/main/java/mods/railcraft/client/render/RenderIronTank.java
+++ b/src/main/java/mods/railcraft/client/render/RenderIronTank.java
@@ -83,7 +83,7 @@ public class RenderIronTank extends TileEntitySpecialRenderer {
         if (tile instanceof TileTankIronValve) {
             TileTankIronValve valve = (TileTankIronValve) tile;
             StandardTank fillTank = valve.getFillTank();
-            if (fillTank.renderData.fluid != null && fillTank.renderData.amount > 0) {
+            if (fillTank.renderData.fluid != null && !fillTank.renderData.fluid.isGaseous() && fillTank.renderData.amount > 0) {
                 GL11.glPushMatrix();
                 if (valve.getPattern().getPatternMarkerChecked(
                         valve.getPatternPositionX(),
@@ -184,6 +184,7 @@ public class RenderIronTank extends TileEntitySpecialRenderer {
         if (tank == null) return;
 
         if (tank.renderData.fluid != null && tank.renderData.amount > 0) {
+            boolean isGas = tank.renderData.fluid.isGaseous();
             preGL();
             GL11.glTranslatef((float) x + 0.5F, (float) y + yOffset + 0.01f, (float) z + 0.5F);
             GL11.glScalef(hScale, vScale, hScale);
@@ -198,8 +199,12 @@ public class RenderIronTank extends TileEntitySpecialRenderer {
 
                 bindTexture(FluidRenderer.getFluidSheet(tank.renderData.fluid));
                 FluidRenderer.setColorForTank(tank);
-                GL11.glCallList(displayLists[(int) (level * (float) (FluidRenderer.DISPLAY_STAGES - 1))]);
-
+                if (isGas) {
+                    GL11.glColor4f(1.0f, 1.0f, 1.0f, 0.3f + level * 0.7f);
+                    GL11.glCallList(displayLists[FluidRenderer.DISPLAY_STAGES - 1]);
+                } else {
+                    GL11.glCallList(displayLists[(int) (level * (float) (FluidRenderer.DISPLAY_STAGES - 1))]);
+                }
                 GL11.glPopMatrix();
             }
 

--- a/src/main/java/mods/railcraft/client/render/RenderIronTank.java
+++ b/src/main/java/mods/railcraft/client/render/RenderIronTank.java
@@ -83,7 +83,8 @@ public class RenderIronTank extends TileEntitySpecialRenderer {
         if (tile instanceof TileTankIronValve) {
             TileTankIronValve valve = (TileTankIronValve) tile;
             StandardTank fillTank = valve.getFillTank();
-            if (fillTank.renderData.fluid != null && !fillTank.renderData.fluid.isGaseous() && fillTank.renderData.amount > 0) {
+            if (fillTank.renderData.fluid != null && !fillTank.renderData.fluid.isGaseous()
+                    && fillTank.renderData.amount > 0) {
                 GL11.glPushMatrix();
                 if (valve.getPattern().getPatternMarkerChecked(
                         valve.getPatternPositionX(),

--- a/src/main/java/mods/railcraft/client/render/carts/CartContentRendererTank.java
+++ b/src/main/java/mods/railcraft/client/render/carts/CartContentRendererTank.java
@@ -36,6 +36,7 @@ public class CartContentRendererTank extends CartContentRenderer {
         StandardTank tank = cartTank.getTankManager().get(0);
         if (tank.renderData.fluid != null && tank.renderData.amount > 0) {
             int[] displayLists = FluidRenderer.getLiquidDisplayLists(tank.renderData.fluid);
+            boolean isGas = tank.renderData.fluid.isGaseous();
             if (displayLists != null) {
                 GL11.glPushMatrix();
 
@@ -50,9 +51,14 @@ public class CartContentRendererTank extends CartContentRenderer {
 
                 renderer.bindTex(FluidRenderer.getFluidSheet(tank.renderData.fluid));
                 FluidRenderer.setColorForTank(tank);
-                GL11.glCallList(displayLists[(int) (level * (float) (FluidRenderer.DISPLAY_STAGES - 1))]);
+                if (isGas) {
+                    GL11.glColor4f(1.0f, 1.0f, 1.0f, Math.max(level, 0.3f + level * 0.7f));
+                    GL11.glCallList(displayLists[FluidRenderer.DISPLAY_STAGES - 1]);
+                } else {   
+                    GL11.glCallList(displayLists[(int) (level * (float) (FluidRenderer.DISPLAY_STAGES - 1))]);
+                }
 
-                if (cartTank.isFilling()) {
+                if (cartTank.isFilling() && !isGas) {
                     ResourceLocation texSheet = FluidRenderer
                             .setupFlowingLiquidTexture(tank.renderData.fluid, fillBlock.texture);
                     if (texSheet != null) {

--- a/src/main/java/mods/railcraft/client/render/carts/CartContentRendererTank.java
+++ b/src/main/java/mods/railcraft/client/render/carts/CartContentRendererTank.java
@@ -36,8 +36,8 @@ public class CartContentRendererTank extends CartContentRenderer {
         StandardTank tank = cartTank.getTankManager().get(0);
         if (tank.renderData.fluid != null && tank.renderData.amount > 0) {
             int[] displayLists = FluidRenderer.getLiquidDisplayLists(tank.renderData.fluid);
-            boolean isGas = tank.renderData.fluid.isGaseous();
             if (displayLists != null) {
+                boolean isGas = tank.renderData.fluid.isGaseous();
                 GL11.glPushMatrix();
 
                 GL11.glPushAttrib(GL11.GL_ENABLE_BIT);

--- a/src/main/java/mods/railcraft/client/render/carts/CartContentRendererTank.java
+++ b/src/main/java/mods/railcraft/client/render/carts/CartContentRendererTank.java
@@ -54,7 +54,7 @@ public class CartContentRendererTank extends CartContentRenderer {
                 if (isGas) {
                     GL11.glColor4f(1.0f, 1.0f, 1.0f, Math.max(level, 0.3f + level * 0.7f));
                     GL11.glCallList(displayLists[FluidRenderer.DISPLAY_STAGES - 1]);
-                } else {   
+                } else {
                     GL11.glCallList(displayLists[(int) (level * (float) (FluidRenderer.DISPLAY_STAGES - 1))]);
                 }
 


### PR DESCRIPTION
This makes gases render by transparency instead of by level.

There is a flat minimum transparency so very transparent gases aren't invisible.

I also culled the "flowing in" animation for gases.

![image](https://github.com/user-attachments/assets/9c03d025-653f-4603-a912-e24232d97fd7)

![image](https://github.com/user-attachments/assets/5e597ec4-0012-40f8-a693-590b1570a7b0)
