### PR TITLE
Only use Gregtech hazard functionality if the Gregtech module is enabled

### DIFF
--- a/src/main/java/mods/railcraft/common/blocks/machine/alpha/TileSteamTrap.java
+++ b/src/main/java/mods/railcraft/common/blocks/machine/alpha/TileSteamTrap.java
@@ -28,6 +28,8 @@ import mods.railcraft.common.fluids.FluidHelper;
 import mods.railcraft.common.fluids.Fluids;
 import mods.railcraft.common.fluids.TankManager;
 import mods.railcraft.common.fluids.tanks.FilteredTank;
+import mods.railcraft.common.modules.ModuleManager;
+import mods.railcraft.common.modules.ModuleManager.Module;
 import mods.railcraft.common.plugins.forge.PowerPlugin;
 import mods.railcraft.common.util.effects.EffectManager;
 import mods.railcraft.common.util.misc.Game;
@@ -78,7 +80,8 @@ public abstract class TileSteamTrap extends TileMachineBase implements ISteamUse
         }
         triggerCheck();
         if (isJetting()) {
-            boolean gt5Loaded = Loader.isModLoaded("gregtech") && !Loader.isModLoaded("gregapi");
+            boolean gt5Loaded = Loader.isModLoaded("gregtech") && !Loader.isModLoaded("gregapi")
+                    && ModuleManager.isModuleLoaded(Module.GREGTECH);
             for (EntityLivingBase entity : getEntitiesInSteamArea()) {
                 if (gt5Loaded && entity instanceof EntityPlayer) {
                     EntityPlayer player = (EntityPlayer) entity;

--- a/src/main/java/mods/railcraft/common/blocks/machine/alpha/TileSteamTrap.java
+++ b/src/main/java/mods/railcraft/common/blocks/machine/alpha/TileSteamTrap.java
@@ -21,7 +21,6 @@ import net.minecraftforge.fluids.Fluid;
 import net.minecraftforge.fluids.FluidStack;
 import net.minecraftforge.fluids.FluidTankInfo;
 
-import cpw.mods.fml.common.Loader;
 import gregtech.api.hazards.HazardProtection;
 import mods.railcraft.common.blocks.machine.TileMachineBase;
 import mods.railcraft.common.fluids.FluidHelper;
@@ -80,8 +79,7 @@ public abstract class TileSteamTrap extends TileMachineBase implements ISteamUse
         }
         triggerCheck();
         if (isJetting()) {
-            boolean gt5Loaded = Loader.isModLoaded("gregtech") && !Loader.isModLoaded("gregapi")
-                    && ModuleManager.isModuleLoaded(Module.GREGTECH);
+            boolean gt5Loaded = ModuleManager.isModuleLoaded(Module.GREGTECH);
             for (EntityLivingBase entity : getEntitiesInSteamArea()) {
                 if (gt5Loaded && entity instanceof EntityPlayer) {
                     EntityPlayer player = (EntityPlayer) entity;

--- a/src/main/java/mods/railcraft/common/items/ItemOveralls.java
+++ b/src/main/java/mods/railcraft/common/items/ItemOveralls.java
@@ -20,6 +20,8 @@ import gregtech.api.hazards.IHazardProtector;
 import mods.railcraft.api.core.items.ISafetyPants;
 import mods.railcraft.common.core.RailcraftConstants;
 import mods.railcraft.common.gui.tooltips.ToolTip;
+import mods.railcraft.common.modules.ModuleManager;
+import mods.railcraft.common.modules.ModuleManager.Module;
 import mods.railcraft.common.plugins.forge.CreativePlugin;
 import mods.railcraft.common.util.inventory.InvTools;
 import mods.railcraft.common.util.misc.MiscTools;
@@ -90,6 +92,6 @@ public class ItemOveralls extends ItemArmor implements ISafetyPants, IHazardProt
     @Override
     @Optional.Method(modid = "gregtech")
     public boolean protectsAgainst(ItemStack itemStack, Hazard hazard) {
-        return hazard == Hazard.ELECTRICAL;
+        return (hazard == Hazard.ELECTRICAL) && ModuleManager.isModuleLoaded(Module.GREGTECH);
     }
 }

--- a/src/main/java/mods/railcraft/common/modules/ModuleGT5.java
+++ b/src/main/java/mods/railcraft/common/modules/ModuleGT5.java
@@ -9,7 +9,8 @@ public class ModuleGT5 extends RailcraftModule {
 
     @Override
     public boolean canModuleLoad() {
-        return Loader.isModLoaded("gregtech");
+        // gregapi is a GT6 marker, and this module is not compatible with that
+        return Loader.isModLoaded("gregtech") && !Loader.isModLoaded("gregapi");
     }
 
     @Override
@@ -19,6 +20,6 @@ public class ModuleGT5 extends RailcraftModule {
 
     @Override
     public void printLoadError() {
-        Game.log(Level.INFO, "Module disabled: {0}, Gregtech not detected", this);
+        Game.log(Level.INFO, "Module disabled: {0}, no valid Gregtech version detected", this);
     }
 }


### PR DESCRIPTION
This disables the cross-interactions of Gregtech hazard armor with Railcraft hazards if the "GREGTECH" module is disabled.

The overalls will also no longer work as a hazmat armor without the module.