### PR TITLE
Change `gregtech` optional decorator modid to `gregtech_nh` for GT6 compat

### DIFF
--- a/src/main/java/mods/railcraft/common/blocks/machine/epsilon/TileElectricFeeder.java
+++ b/src/main/java/mods/railcraft/common/blocks/machine/epsilon/TileElectricFeeder.java
@@ -25,10 +25,12 @@ import mods.railcraft.common.util.misc.Game;
  *
  * @author CovertJaguar <http://www.railcraft.info>
  */
+
+// This API exists in all GT versions, don't change to gregtech_nh
 @Optional.InterfaceList(
         value = { @Optional.Interface(
                 iface = "gregtech.api.interfaces.tileentity.IEnergyConnected",
-                modid = "gregtech_nh"), })
+                modid = "gregtech"), })
 public class TileElectricFeeder extends TileMachineBase implements IElectricGrid, ISinkDelegate, IEnergyConnected {
 
     private final ChargeHandler chargeHandler = new ChargeHandler(this, ChargeHandler.ConnectType.BLOCK, 1);
@@ -128,7 +130,7 @@ public class TileElectricFeeder extends TileMachineBase implements IElectricGrid
         return sinkDelegate;
     }
 
-    // probably no problem with these methods and GT6
+    // no problem with these methods and GT6, don't change to gregtech_nh
     @Override
     @Optional.Method(modid = "gregtech")
     public byte getColorization() {

--- a/src/main/java/mods/railcraft/common/blocks/machine/epsilon/TileElectricFeeder.java
+++ b/src/main/java/mods/railcraft/common/blocks/machine/epsilon/TileElectricFeeder.java
@@ -28,7 +28,7 @@ import mods.railcraft.common.util.misc.Game;
 @Optional.InterfaceList(
         value = { @Optional.Interface(
                 iface = "gregtech.api.interfaces.tileentity.IEnergyConnected",
-                modid = "gregtechNH"), })
+                modid = "gregtech_nh"), })
 public class TileElectricFeeder extends TileMachineBase implements IElectricGrid, ISinkDelegate, IEnergyConnected {
 
     private final ChargeHandler chargeHandler = new ChargeHandler(this, ChargeHandler.ConnectType.BLOCK, 1);

--- a/src/main/java/mods/railcraft/common/blocks/machine/epsilon/TileElectricFeeder.java
+++ b/src/main/java/mods/railcraft/common/blocks/machine/epsilon/TileElectricFeeder.java
@@ -28,7 +28,7 @@ import mods.railcraft.common.util.misc.Game;
 @Optional.InterfaceList(
         value = { @Optional.Interface(
                 iface = "gregtech.api.interfaces.tileentity.IEnergyConnected",
-                modid = "gregtech"), })
+                modid = "dreamcraft"), })
 public class TileElectricFeeder extends TileMachineBase implements IElectricGrid, ISinkDelegate, IEnergyConnected {
 
     private final ChargeHandler chargeHandler = new ChargeHandler(this, ChargeHandler.ConnectType.BLOCK, 1);
@@ -128,6 +128,7 @@ public class TileElectricFeeder extends TileMachineBase implements IElectricGrid
         return sinkDelegate;
     }
 
+    // probably no problem with these methods and GT6
     @Override
     @Optional.Method(modid = "gregtech")
     public byte getColorization() {

--- a/src/main/java/mods/railcraft/common/blocks/machine/epsilon/TileElectricFeeder.java
+++ b/src/main/java/mods/railcraft/common/blocks/machine/epsilon/TileElectricFeeder.java
@@ -28,7 +28,7 @@ import mods.railcraft.common.util.misc.Game;
 @Optional.InterfaceList(
         value = { @Optional.Interface(
                 iface = "gregtech.api.interfaces.tileentity.IEnergyConnected",
-                modid = "dreamcraft"), })
+                modid = "gregtechNH"), })
 public class TileElectricFeeder extends TileMachineBase implements IElectricGrid, ISinkDelegate, IEnergyConnected {
 
     private final ChargeHandler chargeHandler = new ChargeHandler(this, ChargeHandler.ConnectType.BLOCK, 1);

--- a/src/main/java/mods/railcraft/common/blocks/machine/gamma/TileEnergyLoader.java
+++ b/src/main/java/mods/railcraft/common/blocks/machine/gamma/TileEnergyLoader.java
@@ -28,10 +28,11 @@ import mods.railcraft.common.plugins.ic2.TileIC2SinkDelegate;
 import mods.railcraft.common.util.misc.Game;
 import mods.railcraft.common.util.network.IGuiReturnHandler;
 
+// This API exists in all GT versions, don't change to gregtech_nh modid
 @Optional.InterfaceList(
         value = { @Optional.Interface(
                 iface = "gregtech.api.interfaces.tileentity.IEnergyConnected",
-                modid = "gregtech_nh"), })
+                modid = "gregtech"), })
 public class TileEnergyLoader extends TileLoaderEnergyBase
         implements ISinkDelegate, IGuiReturnHandler, IEnergyConnected {
 
@@ -218,7 +219,7 @@ public class TileEnergyLoader extends TileLoaderEnergyBase
         return this;
     }
 
-    // probably no problem with these and GT6
+    // No problem with these and other GT versions, dont change modid
     @Override
     @Optional.Method(modid = "gregtech")
     public byte getColorization() {

--- a/src/main/java/mods/railcraft/common/blocks/machine/gamma/TileEnergyLoader.java
+++ b/src/main/java/mods/railcraft/common/blocks/machine/gamma/TileEnergyLoader.java
@@ -31,7 +31,7 @@ import mods.railcraft.common.util.network.IGuiReturnHandler;
 @Optional.InterfaceList(
         value = { @Optional.Interface(
                 iface = "gregtech.api.interfaces.tileentity.IEnergyConnected",
-                modid = "gregtech"), })
+                modid = "dreamcraft"), })
 public class TileEnergyLoader extends TileLoaderEnergyBase
         implements ISinkDelegate, IGuiReturnHandler, IEnergyConnected {
 
@@ -218,6 +218,7 @@ public class TileEnergyLoader extends TileLoaderEnergyBase
         return this;
     }
 
+    // probably no problem with these and GT6
     @Override
     @Optional.Method(modid = "gregtech")
     public byte getColorization() {

--- a/src/main/java/mods/railcraft/common/blocks/machine/gamma/TileEnergyLoader.java
+++ b/src/main/java/mods/railcraft/common/blocks/machine/gamma/TileEnergyLoader.java
@@ -31,7 +31,7 @@ import mods.railcraft.common.util.network.IGuiReturnHandler;
 @Optional.InterfaceList(
         value = { @Optional.Interface(
                 iface = "gregtech.api.interfaces.tileentity.IEnergyConnected",
-                modid = "dreamcraft"), })
+                modid = "gregtechNH"), })
 public class TileEnergyLoader extends TileLoaderEnergyBase
         implements ISinkDelegate, IGuiReturnHandler, IEnergyConnected {
 

--- a/src/main/java/mods/railcraft/common/blocks/machine/gamma/TileEnergyLoader.java
+++ b/src/main/java/mods/railcraft/common/blocks/machine/gamma/TileEnergyLoader.java
@@ -31,7 +31,7 @@ import mods.railcraft.common.util.network.IGuiReturnHandler;
 @Optional.InterfaceList(
         value = { @Optional.Interface(
                 iface = "gregtech.api.interfaces.tileentity.IEnergyConnected",
-                modid = "gregtechNH"), })
+                modid = "gregtech_nh"), })
 public class TileEnergyLoader extends TileLoaderEnergyBase
         implements ISinkDelegate, IGuiReturnHandler, IEnergyConnected {
 

--- a/src/main/java/mods/railcraft/common/blocks/tracks/BlockTrack.java
+++ b/src/main/java/mods/railcraft/common/blocks/tracks/BlockTrack.java
@@ -257,7 +257,7 @@ public class BlockTrack extends BlockRailBase implements IPostConnection {
         } ;
     }
 
-    @Optional.method(modid = "dreamcraft")
+    @Optional.method(modid = "gregtechNH")
     private static boolean isShockProtectedHazmat(EntityPlayer player) {
         ItemStack pants = player.getCurrentArmor(MiscTools.ArmorSlots.LEGS.ordinal());
         if (HazardProtection.protectsAgainstHazard(pants, Hazard.ELECTRICAL)) {

--- a/src/main/java/mods/railcraft/common/blocks/tracks/BlockTrack.java
+++ b/src/main/java/mods/railcraft/common/blocks/tracks/BlockTrack.java
@@ -38,6 +38,7 @@ import net.minecraftforge.common.util.ForgeDirection;
 
 import org.apache.logging.log4j.Level;
 
+import cpw.mods.fml.common.Optional;
 import cpw.mods.fml.common.registry.GameRegistry;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
@@ -257,7 +258,7 @@ public class BlockTrack extends BlockRailBase implements IPostConnection {
         } ;
     }
 
-    @Optional.method(modid = "gregtech_nh")
+    @Optional.Method(modid = "gregtech_nh")
     private static boolean isShockProtectedHazmat(EntityPlayer player) {
         ItemStack pants = player.getCurrentArmor(MiscTools.ArmorSlots.LEGS.ordinal());
         if (HazardProtection.protectsAgainstHazard(pants, Hazard.ELECTRICAL)) {

--- a/src/main/java/mods/railcraft/common/blocks/tracks/BlockTrack.java
+++ b/src/main/java/mods/railcraft/common/blocks/tracks/BlockTrack.java
@@ -257,6 +257,7 @@ public class BlockTrack extends BlockRailBase implements IPostConnection {
         } ;
     }
 
+    @Optional.method(modid = "dreamcraft")
     private static boolean isShockProtectedHazmat(EntityPlayer player) {
         ItemStack pants = player.getCurrentArmor(MiscTools.ArmorSlots.LEGS.ordinal());
         if (HazardProtection.protectsAgainstHazard(pants, Hazard.ELECTRICAL)) {

--- a/src/main/java/mods/railcraft/common/blocks/tracks/BlockTrack.java
+++ b/src/main/java/mods/railcraft/common/blocks/tracks/BlockTrack.java
@@ -257,7 +257,7 @@ public class BlockTrack extends BlockRailBase implements IPostConnection {
         } ;
     }
 
-    @Optional.method(modid = "gregtechNH")
+    @Optional.method(modid = "gregtech_nh")
     private static boolean isShockProtectedHazmat(EntityPlayer player) {
         ItemStack pants = player.getCurrentArmor(MiscTools.ArmorSlots.LEGS.ordinal());
         if (HazardProtection.protectsAgainstHazard(pants, Hazard.ELECTRICAL)) {

--- a/src/main/java/mods/railcraft/common/items/ItemOveralls.java
+++ b/src/main/java/mods/railcraft/common/items/ItemOveralls.java
@@ -31,7 +31,7 @@ import mods.railcraft.common.util.misc.MiscTools;
  * @author CovertJaguar <http://www.railcraft.info>
  */
 @Optional.InterfaceList(
-        value = { @Optional.Interface(iface = "gregtech.api.hazards.IHazardProtector", modid = "gregtechNH"), })
+        value = { @Optional.Interface(iface = "gregtech.api.hazards.IHazardProtector", modid = "gregtech_nh"), })
 public class ItemOveralls extends ItemArmor implements ISafetyPants, IHazardProtector {
 
     private static final ItemStack BLUE_CLOTH = new ItemStack(Blocks.wool, 1, 3);
@@ -90,7 +90,7 @@ public class ItemOveralls extends ItemArmor implements ISafetyPants, IHazardProt
     }
 
     @Override
-    @Optional.Method(modid = "gregtechNH")
+    @Optional.Method(modid = "gregtech_nh")
     public boolean protectsAgainst(ItemStack itemStack, Hazard hazard) {
         return (hazard == Hazard.ELECTRICAL) && ModuleManager.isModuleLoaded(Module.GREGTECH);
     }

--- a/src/main/java/mods/railcraft/common/items/ItemOveralls.java
+++ b/src/main/java/mods/railcraft/common/items/ItemOveralls.java
@@ -31,7 +31,7 @@ import mods.railcraft.common.util.misc.MiscTools;
  * @author CovertJaguar <http://www.railcraft.info>
  */
 @Optional.InterfaceList(
-        value = { @Optional.Interface(iface = "gregtech.api.hazards.IHazardProtector", modid = "gregtech"), })
+        value = { @Optional.Interface(iface = "gregtech.api.hazards.IHazardProtector", modid = "dreamcraft"), })
 public class ItemOveralls extends ItemArmor implements ISafetyPants, IHazardProtector {
 
     private static final ItemStack BLUE_CLOTH = new ItemStack(Blocks.wool, 1, 3);
@@ -90,7 +90,7 @@ public class ItemOveralls extends ItemArmor implements ISafetyPants, IHazardProt
     }
 
     @Override
-    @Optional.Method(modid = "gregtech")
+    @Optional.Method(modid = "dreamcraft")
     public boolean protectsAgainst(ItemStack itemStack, Hazard hazard) {
         return (hazard == Hazard.ELECTRICAL) && ModuleManager.isModuleLoaded(Module.GREGTECH);
     }

--- a/src/main/java/mods/railcraft/common/items/ItemOveralls.java
+++ b/src/main/java/mods/railcraft/common/items/ItemOveralls.java
@@ -31,7 +31,7 @@ import mods.railcraft.common.util.misc.MiscTools;
  * @author CovertJaguar <http://www.railcraft.info>
  */
 @Optional.InterfaceList(
-        value = { @Optional.Interface(iface = "gregtech.api.hazards.IHazardProtector", modid = "dreamcraft"), })
+        value = { @Optional.Interface(iface = "gregtech.api.hazards.IHazardProtector", modid = "gregtechNH"), })
 public class ItemOveralls extends ItemArmor implements ISafetyPants, IHazardProtector {
 
     private static final ItemStack BLUE_CLOTH = new ItemStack(Blocks.wool, 1, 3);
@@ -90,7 +90,7 @@ public class ItemOveralls extends ItemArmor implements ISafetyPants, IHazardProt
     }
 
     @Override
-    @Optional.Method(modid = "dreamcraft")
+    @Optional.Method(modid = "gregtechNH")
     public boolean protectsAgainst(ItemStack itemStack, Hazard hazard) {
         return (hazard == Hazard.ELECTRICAL) && ModuleManager.isModuleLoaded(Module.GREGTECH);
     }


### PR DESCRIPTION
If anyone has an answer that works when just gt5 without dreamcraft is loaded feel free to push that (assuming standalone gt5 uses the new api)