### PR TITLE
Fixes stairs metadata display

### DIFF
--- a/src/main/java/mods/railcraft/common/blocks/aesthetics/stairs/BlockRailcraftStairs.java
+++ b/src/main/java/mods/railcraft/common/blocks/aesthetics/stairs/BlockRailcraftStairs.java
@@ -81,6 +81,11 @@ public class BlockRailcraftStairs extends BlockStairs implements IBlockSoundProv
 
     @Override
     public ItemStack getPickBlock(MovingObjectPosition target, World world, int x, int y, int z, EntityPlayer player) {
+        return getPickBlock(target, world, x, y, z);
+    }
+
+    @Override
+    public ItemStack getPickBlock(MovingObjectPosition target, World world, int x, int y, int z) {
         TileEntity tile = world.getTileEntity(x, y, z);
         if (tile instanceof TileStair) return new ItemStack(this, 1, ((TileStair) tile).getStair().ordinal());
         return null;


### PR DESCRIPTION
Fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/24169
<img width="651" height="1398" alt="yes" src="https://github.com/user-attachments/assets/a048665e-1de1-4652-acd3-2cb10c764505" />

All stairs with different metadata were displayed as ID:0 (Sandy Brick Stairs)

Reference: https://github.com/GTNewHorizons/Railcraft/blob/8f592e731f7bd1e0fe7a83fea722c72e32c99f8e/src/main/java/mods/railcraft/common/blocks/aesthetics/slab/BlockRailcraftSlab.java#L102-L108