### PR TITLE
fix type casting issue

### DIFF
--- a/src/main/java/mods/railcraft/common/fluids/TankManager.java
+++ b/src/main/java/mods/railcraft/common/fluids/TankManager.java
@@ -31,7 +31,6 @@ import mods.railcraft.common.plugins.forge.NBTPlugin;
 import mods.railcraft.common.plugins.forge.NBTPlugin.NBTList;
 import mods.railcraft.common.util.misc.AdjacentTileCache;
 import mods.railcraft.common.util.misc.ITileFilter;
-import mods.railcraft.common.util.network.PacketBuilder;
 
 /**
  * @author CovertJaguar <http://www.railcraft.info>
@@ -46,6 +45,8 @@ public class TankManager extends ForwardingList<StandardTank> implements IFluidH
         }
     };
     private static final byte NETWORK_DATA = 3;
+    private static final int EXTENDED_NETWORK_DATA = 2;
+    private static final int EXTENDED_NETWORK_DATA_BASE = 256;
     private final List<StandardTank> tanks = new ArrayList<StandardTank>();
 
     public TankManager() {}
@@ -141,10 +142,7 @@ public class TankManager extends ForwardingList<StandardTank> implements IFluidH
             fluidAmount = fluidStack.amount;
         }
 
-        player.sendProgressBarUpdate(container, tankIndex * NETWORK_DATA + 0, fluidId);
-        PacketBuilder.instance()
-                .sendGuiIntegerPacket(player, container.windowId, tankIndex * NETWORK_DATA + 1, fluidAmount);
-        PacketBuilder.instance().sendGuiIntegerPacket(player, container.windowId, tankIndex * NETWORK_DATA + 2, color);
+        sendFluidGuiData(container, player, tankIndex, fluidId, fluidAmount, color);
 
         tank.renderData.fluid = tank.getFluidType();
         tank.renderData.amount = fluidAmount;
@@ -165,21 +163,28 @@ public class TankManager extends ForwardingList<StandardTank> implements IFluidH
                     fluidId = FluidHelper.getFluidId(fluidStack);
                     fluidAmount = fluidStack.amount;
                 }
-                crafter.sendProgressBarUpdate(container, tankIndex * NETWORK_DATA + 0, fluidId);
-                PacketBuilder.instance()
-                        .sendGuiIntegerPacket(crafter, container.windowId, tankIndex * NETWORK_DATA + 1, fluidAmount);
+                sendFluidGuiData(container, crafter, tankIndex, fluidId, fluidAmount, color);
             } else if (fluidStack != null && tank.renderData.fluid != null) {
                 if (fluidStack.getFluid() != tank.renderData.fluid) crafter.sendProgressBarUpdate(
                         container,
-                        tankIndex * NETWORK_DATA + 0,
+                        getFluidMessageId(tankIndex),
                         FluidHelper.getFluidId(fluidStack));
-                if (fluidStack.amount != tank.renderData.amount) PacketBuilder.instance().sendGuiIntegerPacket(
-                        crafter,
-                        container.windowId,
-                        tankIndex * NETWORK_DATA + 1,
-                        fluidStack.amount);
-                if (color != pColor) PacketBuilder.instance()
-                        .sendGuiIntegerPacket(crafter, container.windowId, tankIndex * NETWORK_DATA + 2, color);
+                if (fluidStack.amount != tank.renderData.amount) {
+                    sendSplitInt(
+                            container,
+                            crafter,
+                            getAmountMessageId(tankIndex),
+                            getAmountHighMessageId(tankIndex),
+                            fluidStack.amount);
+                }
+                if (color != pColor) {
+                    sendSplitInt(
+                            container,
+                            crafter,
+                            getColorMessageId(tankIndex),
+                            getColorHighMessageId(tankIndex),
+                            color);
+                }
             }
         }
 
@@ -189,21 +194,85 @@ public class TankManager extends ForwardingList<StandardTank> implements IFluidH
     }
 
     public void processGuiUpdate(int messageId, int data) {
-        int tankIndex = messageId / NETWORK_DATA;
+        if (messageId >= EXTENDED_NETWORK_DATA_BASE) {
+            int tankIndex = (messageId - EXTENDED_NETWORK_DATA_BASE) / EXTENDED_NETWORK_DATA;
+            if (tankIndex >= tanks.size()) return;
 
+            StandardTank tank = tanks.get(tankIndex);
+            switch ((messageId - EXTENDED_NETWORK_DATA_BASE) % EXTENDED_NETWORK_DATA) {
+                case 0:
+                    tank.renderData.amount = mergeHighWord(tank.renderData.amount, data);
+                    break;
+                case 1:
+                    tank.renderData.color = mergeHighWord(tank.renderData.color, data);
+                    break;
+            }
+            return;
+        }
+
+        int tankIndex = messageId / NETWORK_DATA;
         if (tankIndex >= tanks.size()) return;
+
         StandardTank tank = tanks.get(tankIndex);
         switch (messageId % NETWORK_DATA) {
             case 0:
-                tank.renderData.fluid = FluidRegistry.getFluid(data);
+                tank.renderData.fluid = data < 0 ? null : FluidRegistry.getFluid(data);
                 break;
             case 1:
-                tank.renderData.amount = data;
+                tank.renderData.amount = mergeLowWord(tank.renderData.amount, data);
                 break;
             case 2:
-                tank.renderData.color = data;
+                tank.renderData.color = mergeLowWord(tank.renderData.color, data);
                 break;
         }
+    }
+
+    private void sendFluidGuiData(Container container, ICrafting crafter, int tankIndex, int fluidId, int fluidAmount,
+            int color) {
+        crafter.sendProgressBarUpdate(container, getFluidMessageId(tankIndex), fluidId);
+        sendSplitInt(container, crafter, getAmountMessageId(tankIndex), getAmountHighMessageId(tankIndex), fluidAmount);
+        sendSplitInt(container, crafter, getColorMessageId(tankIndex), getColorHighMessageId(tankIndex), color);
+    }
+
+    private void sendSplitInt(Container container, ICrafting crafter, int lowMessageId, int highMessageId, int value) {
+        crafter.sendProgressBarUpdate(container, lowMessageId, getLowWord(value));
+        crafter.sendProgressBarUpdate(container, highMessageId, getHighWord(value));
+    }
+
+    private static int getFluidMessageId(int tankIndex) {
+        return tankIndex * NETWORK_DATA;
+    }
+
+    private static int getAmountMessageId(int tankIndex) {
+        return tankIndex * NETWORK_DATA + 1;
+    }
+
+    private static int getColorMessageId(int tankIndex) {
+        return tankIndex * NETWORK_DATA + 2;
+    }
+
+    private static int getAmountHighMessageId(int tankIndex) {
+        return EXTENDED_NETWORK_DATA_BASE + tankIndex * EXTENDED_NETWORK_DATA;
+    }
+
+    private static int getColorHighMessageId(int tankIndex) {
+        return EXTENDED_NETWORK_DATA_BASE + tankIndex * EXTENDED_NETWORK_DATA + 1;
+    }
+
+    private static int getLowWord(int value) {
+        return value & 0xFFFF;
+    }
+
+    private static int getHighWord(int value) {
+        return value >>> 16;
+    }
+
+    private static int mergeLowWord(int value, int lowWord) {
+        return (value & 0xFFFF0000) | (lowWord & 0xFFFF);
+    }
+
+    private static int mergeHighWord(int value, int highWord) {
+        return ((highWord & 0xFFFF) << 16) | (value & 0xFFFF);
     }
 
     @Override

--- a/src/main/java/mods/railcraft/common/fluids/TankManager.java
+++ b/src/main/java/mods/railcraft/common/fluids/TankManager.java
@@ -12,7 +12,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
-import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.inventory.Container;
 import net.minecraft.inventory.ICrafting;
 import net.minecraft.nbt.NBTTagCompound;
@@ -143,28 +142,22 @@ public class TankManager extends ForwardingList<StandardTank> implements IFluidH
         }
 
         player.sendProgressBarUpdate(container, tankIndex * NETWORK_DATA + 0, fluidId);
-        PacketBuilder.instance().sendGuiIntegerPacket(
-                (EntityPlayerMP) player,
-                container.windowId,
-                tankIndex * NETWORK_DATA + 1,
-                fluidAmount);
         PacketBuilder.instance()
-                .sendGuiIntegerPacket((EntityPlayerMP) player, container.windowId, tankIndex * NETWORK_DATA + 2, color);
+                .sendGuiIntegerPacket(player, container.windowId, tankIndex * NETWORK_DATA + 1, fluidAmount);
+        PacketBuilder.instance().sendGuiIntegerPacket(player, container.windowId, tankIndex * NETWORK_DATA + 2, color);
 
         tank.renderData.fluid = tank.getFluidType();
         tank.renderData.amount = fluidAmount;
         tank.renderData.color = color;
     }
 
-    public void updateGuiData(Container container, List crafters, int tankIndex) {
+    public void updateGuiData(Container container, List<ICrafting> crafters, int tankIndex) {
         StandardTank tank = tanks.get(tankIndex);
         FluidStack fluidStack = tank.getFluid();
         int color = tank.getColor();
         int pColor = tank.renderData.color;
 
-        for (Object crafter1 : crafters) {
-            ICrafting crafter = (ICrafting) crafter1;
-            EntityPlayerMP player = (EntityPlayerMP) crafter1;
+        for (ICrafting crafter : crafters) {
             if (fluidStack == null ^ tank.renderData.fluid == null) {
                 int fluidId = -1;
                 int fluidAmount = 0;
@@ -174,19 +167,19 @@ public class TankManager extends ForwardingList<StandardTank> implements IFluidH
                 }
                 crafter.sendProgressBarUpdate(container, tankIndex * NETWORK_DATA + 0, fluidId);
                 PacketBuilder.instance()
-                        .sendGuiIntegerPacket(player, container.windowId, tankIndex * NETWORK_DATA + 1, fluidAmount);
+                        .sendGuiIntegerPacket(crafter, container.windowId, tankIndex * NETWORK_DATA + 1, fluidAmount);
             } else if (fluidStack != null && tank.renderData.fluid != null) {
                 if (fluidStack.getFluid() != tank.renderData.fluid) crafter.sendProgressBarUpdate(
                         container,
                         tankIndex * NETWORK_DATA + 0,
                         FluidHelper.getFluidId(fluidStack));
                 if (fluidStack.amount != tank.renderData.amount) PacketBuilder.instance().sendGuiIntegerPacket(
-                        player,
+                        crafter,
                         container.windowId,
                         tankIndex * NETWORK_DATA + 1,
                         fluidStack.amount);
                 if (color != pColor) PacketBuilder.instance()
-                        .sendGuiIntegerPacket(player, container.windowId, tankIndex * NETWORK_DATA + 2, color);
+                        .sendGuiIntegerPacket(crafter, container.windowId, tankIndex * NETWORK_DATA + 2, color);
             }
         }
 

--- a/src/main/java/mods/railcraft/common/gui/containers/ContainerAspectAction.java
+++ b/src/main/java/mods/railcraft/common/gui/containers/ContainerAspectAction.java
@@ -6,7 +6,6 @@
 package mods.railcraft.common.gui.containers;
 
 import net.minecraft.entity.player.EntityPlayer;
-import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.inventory.ICrafting;
 
 import cpw.mods.fml.relauncher.Side;
@@ -37,8 +36,7 @@ public class ContainerAspectAction extends RailcraftContainer {
         icrafting.sendProgressBarUpdate(this, 1, PlayerPlugin.isOwnerOrOp(actionManager.getOwner(), player) ? 1 : 0);
 
         String username = actionManager.getOwner().getName();
-        if (username != null)
-            PacketBuilder.instance().sendGuiStringPacket((EntityPlayerMP) icrafting, windowId, 0, username);
+        if (username != null) PacketBuilder.instance().sendGuiStringPacket(icrafting, windowId, 0, username);
     }
 
     @Override

--- a/src/main/java/mods/railcraft/common/gui/containers/ContainerBlastFurnace.java
+++ b/src/main/java/mods/railcraft/common/gui/containers/ContainerBlastFurnace.java
@@ -5,7 +5,6 @@
  */
 package mods.railcraft.common.gui.containers;
 
-import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.entity.player.InventoryPlayer;
 import net.minecraft.inventory.ICrafting;
 import net.minecraft.inventory.Slot;
@@ -47,9 +46,8 @@ public class ContainerBlastFurnace extends RailcraftContainer {
     public void addCraftingToCrafters(ICrafting player) {
         super.addCraftingToCrafters(player);
         player.sendProgressBarUpdate(this, 0, furnace.getCookTime());
-        PacketBuilder.instance().sendGuiIntegerPacket((EntityPlayerMP) player, windowId, 1, furnace.burnTime);
-        PacketBuilder.instance()
-                .sendGuiIntegerPacket((EntityPlayerMP) player, windowId, 2, furnace.currentItemBurnTime);
+        PacketBuilder.instance().sendGuiIntegerPacket(player, windowId, 1, furnace.burnTime);
+        PacketBuilder.instance().sendGuiIntegerPacket(player, windowId, 2, furnace.currentItemBurnTime);
     }
 
     /**
@@ -65,10 +63,10 @@ public class ContainerBlastFurnace extends RailcraftContainer {
             if (lastCookTime != furnace.getCookTime()) player.sendProgressBarUpdate(this, 0, furnace.getCookTime());
 
             if (lastBurnTime != furnace.burnTime)
-                PacketBuilder.instance().sendGuiIntegerPacket((EntityPlayerMP) player, windowId, 1, furnace.burnTime);
+                PacketBuilder.instance().sendGuiIntegerPacket(player, windowId, 1, furnace.burnTime);
 
-            if (lastItemBurnTime != furnace.currentItemBurnTime) PacketBuilder.instance()
-                    .sendGuiIntegerPacket((EntityPlayerMP) player, windowId, 2, furnace.currentItemBurnTime);
+            if (lastItemBurnTime != furnace.currentItemBurnTime)
+                PacketBuilder.instance().sendGuiIntegerPacket(player, windowId, 2, furnace.currentItemBurnTime);
         }
 
         lastCookTime = furnace.getCookTime();

--- a/src/main/java/mods/railcraft/common/gui/containers/ContainerCartEnergy.java
+++ b/src/main/java/mods/railcraft/common/gui/containers/ContainerCartEnergy.java
@@ -5,7 +5,6 @@
  */
 package mods.railcraft.common.gui.containers;
 
-import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.entity.player.InventoryPlayer;
 import net.minecraft.inventory.ICrafting;
 import net.minecraft.inventory.Slot;
@@ -40,7 +39,7 @@ public class ContainerCartEnergy extends RailcraftContainer {
     @Override
     public void addCraftingToCrafters(ICrafting player) {
         super.addCraftingToCrafters(player);
-        PacketBuilder.instance().sendGuiIntegerPacket((EntityPlayerMP) player, windowId, 0, (int) cart.getEnergy());
+        PacketBuilder.instance().sendGuiIntegerPacket(player, windowId, 0, (int) cart.getEnergy());
     }
 
     /**
@@ -53,8 +52,8 @@ public class ContainerCartEnergy extends RailcraftContainer {
         for (int i = 0; i < crafters.size(); ++i) {
             ICrafting player = (ICrafting) crafters.get(i);
 
-            if (lastEnergy != cart.getEnergy()) PacketBuilder.instance()
-                    .sendGuiIntegerPacket((EntityPlayerMP) player, windowId, 0, (int) cart.getEnergy());
+            if (lastEnergy != cart.getEnergy())
+                PacketBuilder.instance().sendGuiIntegerPacket(player, windowId, 0, (int) cart.getEnergy());
         }
 
         lastEnergy = (int) cart.getEnergy();

--- a/src/main/java/mods/railcraft/common/gui/containers/ContainerCartRF.java
+++ b/src/main/java/mods/railcraft/common/gui/containers/ContainerCartRF.java
@@ -5,7 +5,6 @@
  */
 package mods.railcraft.common.gui.containers;
 
-import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.inventory.ICrafting;
 
 import cpw.mods.fml.relauncher.Side;
@@ -31,7 +30,7 @@ public class ContainerCartRF extends RailcraftContainer {
     public void addCraftingToCrafters(ICrafting crafter) {
         super.addCraftingToCrafters(crafter);
 
-        PacketBuilder.instance().sendGuiIntegerPacket((EntityPlayerMP) crafter, windowId, 0, cart.getRF());
+        PacketBuilder.instance().sendGuiIntegerPacket(crafter, windowId, 0, cart.getRF());
     }
 
     @Override
@@ -42,7 +41,7 @@ public class ContainerCartRF extends RailcraftContainer {
             ICrafting crafter = (ICrafting) crafters.get(var1);
 
             if (lastEnergy != cart.getRF())
-                PacketBuilder.instance().sendGuiIntegerPacket((EntityPlayerMP) crafter, windowId, 0, cart.getRF());
+                PacketBuilder.instance().sendGuiIntegerPacket(crafter, windowId, 0, cart.getRF());
         }
 
         this.lastEnergy = cart.getRF();

--- a/src/main/java/mods/railcraft/common/gui/containers/ContainerEnergyLoader.java
+++ b/src/main/java/mods/railcraft/common/gui/containers/ContainerEnergyLoader.java
@@ -5,7 +5,6 @@
  */
 package mods.railcraft.common.gui.containers;
 
-import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.entity.player.InventoryPlayer;
 import net.minecraft.inventory.ICrafting;
 import net.minecraft.inventory.Slot;
@@ -48,7 +47,7 @@ public class ContainerEnergyLoader extends RailcraftContainer {
     @Override
     public void addCraftingToCrafters(ICrafting player) {
         super.addCraftingToCrafters(player);
-        PacketBuilder.instance().sendGuiIntegerPacket((EntityPlayerMP) player, windowId, 0, (int) device.getEnergy());
+        PacketBuilder.instance().sendGuiIntegerPacket(player, windowId, 0, (int) device.getEnergy());
         player.sendProgressBarUpdate(this, 1, device.storageUpgrades);
         player.sendProgressBarUpdate(this, 2, device.lapotronUpgrades);
         player.sendProgressBarUpdate(this, 3, device.transferRate);
@@ -64,8 +63,8 @@ public class ContainerEnergyLoader extends RailcraftContainer {
         for (int i = 0; i < crafters.size(); ++i) {
             ICrafting player = (ICrafting) crafters.get(i);
 
-            if (lastEnergy != device.getEnergy()) PacketBuilder.instance()
-                    .sendGuiIntegerPacket((EntityPlayerMP) player, windowId, 0, (int) device.getEnergy());
+            if (lastEnergy != device.getEnergy())
+                PacketBuilder.instance().sendGuiIntegerPacket(player, windowId, 0, (int) device.getEnergy());
 
             if (lastStorage != device.storageUpgrades) player.sendProgressBarUpdate(this, 1, device.storageUpgrades);
 

--- a/src/main/java/mods/railcraft/common/gui/containers/ContainerEngineSteam.java
+++ b/src/main/java/mods/railcraft/common/gui/containers/ContainerEngineSteam.java
@@ -6,7 +6,6 @@
 package mods.railcraft.common.gui.containers;
 
 import net.minecraft.entity.player.EntityPlayer;
-import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.entity.player.InventoryPlayer;
 import net.minecraft.inventory.ICrafting;
 import net.minecraft.inventory.Slot;
@@ -51,7 +50,7 @@ public class ContainerEngineSteam extends RailcraftContainer {
         super.addCraftingToCrafters(crafter);
         tile.getTankManager().initGuiData(this, crafter, 0);
 
-        PacketBuilder.instance().sendGuiIntegerPacket((EntityPlayerMP) crafter, windowId, 12, tile.energy);
+        PacketBuilder.instance().sendGuiIntegerPacket(crafter, windowId, 12, tile.energy);
         crafter.sendProgressBarUpdate(this, 14, Math.round(tile.currentOutput * 100));
     }
 
@@ -64,7 +63,7 @@ public class ContainerEngineSteam extends RailcraftContainer {
             ICrafting crafter = (ICrafting) this.crafters.get(var1);
 
             if (this.lastEnergy != tile.energy)
-                PacketBuilder.instance().sendGuiIntegerPacket((EntityPlayerMP) crafter, windowId, 13, tile.energy);
+                PacketBuilder.instance().sendGuiIntegerPacket(crafter, windowId, 13, tile.energy);
 
             if (this.lastOutput != tile.currentOutput)
                 crafter.sendProgressBarUpdate(this, 14, Math.round(tile.currentOutput * 100));

--- a/src/main/java/mods/railcraft/common/gui/containers/ContainerEngineSteamHobby.java
+++ b/src/main/java/mods/railcraft/common/gui/containers/ContainerEngineSteamHobby.java
@@ -5,7 +5,6 @@
  */
 package mods.railcraft.common.gui.containers;
 
-import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.entity.player.InventoryPlayer;
 import net.minecraft.inventory.ICrafting;
 import net.minecraft.inventory.Slot;
@@ -67,7 +66,7 @@ public class ContainerEngineSteamHobby extends RailcraftContainer {
         crafter.sendProgressBarUpdate(this, 11, (int) Math.round(tile.boiler.currentItemBurnTime));
         crafter.sendProgressBarUpdate(this, 12, (int) Math.round(tile.currentOutput * 100));
         crafter.sendProgressBarUpdate(this, 13, (int) Math.round(tile.boiler.getHeat()));
-        PacketBuilder.instance().sendGuiIntegerPacket((EntityPlayerMP) crafter, windowId, 14, tile.energy);
+        PacketBuilder.instance().sendGuiIntegerPacket(crafter, windowId, 14, tile.energy);
     }
 
     @Override
@@ -92,7 +91,7 @@ public class ContainerEngineSteamHobby extends RailcraftContainer {
                 crafter.sendProgressBarUpdate(this, 13, (int) Math.round(tile.boiler.getHeat()));
 
             if (this.lastEnergy != tile.energy)
-                PacketBuilder.instance().sendGuiIntegerPacket((EntityPlayerMP) crafter, windowId, 15, tile.energy);
+                PacketBuilder.instance().sendGuiIntegerPacket(crafter, windowId, 15, tile.energy);
         }
 
         this.lastBurnTime = tile.boiler.burnTime;

--- a/src/main/java/mods/railcraft/common/gui/containers/ContainerLoaderRF.java
+++ b/src/main/java/mods/railcraft/common/gui/containers/ContainerLoaderRF.java
@@ -5,7 +5,6 @@
  */
 package mods.railcraft.common.gui.containers;
 
-import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.inventory.ICrafting;
 
 import cpw.mods.fml.relauncher.Side;
@@ -31,7 +30,7 @@ public class ContainerLoaderRF extends RailcraftContainer {
     @Override
     public void addCraftingToCrafters(ICrafting player) {
         super.addCraftingToCrafters(player);
-        PacketBuilder.instance().sendGuiIntegerPacket((EntityPlayerMP) player, windowId, 0, device.getRF());
+        PacketBuilder.instance().sendGuiIntegerPacket(player, windowId, 0, device.getRF());
     }
 
     /**
@@ -45,7 +44,7 @@ public class ContainerLoaderRF extends RailcraftContainer {
             ICrafting player = (ICrafting) crafters.get(i);
 
             if (lastEnergy != device.getRF())
-                PacketBuilder.instance().sendGuiIntegerPacket((EntityPlayerMP) player, windowId, 0, device.getRF());
+                PacketBuilder.instance().sendGuiIntegerPacket(player, windowId, 0, device.getRF());
         }
 
         lastEnergy = device.getRF();

--- a/src/main/java/mods/railcraft/common/gui/containers/ContainerLocomotive.java
+++ b/src/main/java/mods/railcraft/common/gui/containers/ContainerLocomotive.java
@@ -5,7 +5,6 @@
  */
 package mods.railcraft.common.gui.containers;
 
-import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.entity.player.InventoryPlayer;
 import net.minecraft.inventory.ICrafting;
 import net.minecraft.inventory.Slot;
@@ -88,7 +87,7 @@ public class ContainerLocomotive extends RailcraftContainer {
         icrafting.sendProgressBarUpdate(this, 13, PlayerPlugin.isOwnerOrOp(loco.getOwner(), playerInv.player) ? 1 : 0);
 
         String oName = loco.getOwner().getName();
-        if (oName != null) PacketBuilder.instance().sendGuiStringPacket((EntityPlayerMP) icrafting, windowId, 0, oName);
+        if (oName != null) PacketBuilder.instance().sendGuiStringPacket(icrafting, windowId, 0, oName);
     }
 
     @Override

--- a/src/main/java/mods/railcraft/common/gui/containers/ContainerRouting.java
+++ b/src/main/java/mods/railcraft/common/gui/containers/ContainerRouting.java
@@ -5,7 +5,6 @@
  */
 package mods.railcraft.common.gui.containers;
 
-import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.entity.player.InventoryPlayer;
 import net.minecraft.inventory.ICrafting;
 import net.minecraft.inventory.Slot;
@@ -84,8 +83,7 @@ public class ContainerRouting extends RailcraftContainer {
         icrafting.sendProgressBarUpdate(this, 2, canLock ? 1 : 0);
 
         String username = router.getOwner().getName();
-        if (username != null)
-            PacketBuilder.instance().sendGuiStringPacket((EntityPlayerMP) icrafting, windowId, 0, username);
+        if (username != null) PacketBuilder.instance().sendGuiStringPacket(icrafting, windowId, 0, username);
     }
 
     @Override

--- a/src/main/java/mods/railcraft/common/gui/containers/ContainerTrackRouting.java
+++ b/src/main/java/mods/railcraft/common/gui/containers/ContainerTrackRouting.java
@@ -5,7 +5,6 @@
  */
 package mods.railcraft.common.gui.containers;
 
-import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.entity.player.InventoryPlayer;
 import net.minecraft.inventory.ICrafting;
 import net.minecraft.inventory.Slot;
@@ -59,8 +58,7 @@ public class ContainerTrackRouting extends RailcraftContainer {
         icrafting.sendProgressBarUpdate(this, 2, canLock ? 1 : 0);
 
         String username = track.getOwner().getName();
-        if (username != null)
-            PacketBuilder.instance().sendGuiStringPacket((EntityPlayerMP) icrafting, windowId, 0, username);
+        if (username != null) PacketBuilder.instance().sendGuiStringPacket(icrafting, windowId, 0, username);
     }
 
     @Override

--- a/src/main/java/mods/railcraft/common/gui/containers/RailcraftContainer.java
+++ b/src/main/java/mods/railcraft/common/gui/containers/RailcraftContainer.java
@@ -11,7 +11,6 @@ import java.util.ArrayList;
 import java.util.List;
 
 import net.minecraft.entity.player.EntityPlayer;
-import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.entity.player.InventoryPlayer;
 import net.minecraft.inventory.Container;
 import net.minecraft.inventory.ICrafting;
@@ -80,7 +79,7 @@ public abstract class RailcraftContainer extends Container {
     public void sendUpdateToClient() {}
 
     public void sendWidgetDataToClient(Widget widget, ICrafting player, byte[] data) {
-        PacketBuilder.instance().sendGuiWidgetPacket((EntityPlayerMP) player, windowId, widgets.indexOf(widget), data);
+        PacketBuilder.instance().sendGuiWidgetPacket(player, windowId, widgets.indexOf(widget), data);
     }
 
     public void handleWidgetClientData(int widgetId, DataInputStream data) throws IOException {

--- a/src/main/java/mods/railcraft/common/util/network/PacketBuilder.java
+++ b/src/main/java/mods/railcraft/common/util/network/PacketBuilder.java
@@ -6,6 +6,7 @@
 package mods.railcraft.common.util.network;
 
 import net.minecraft.entity.player.EntityPlayerMP;
+import net.minecraft.inventory.ICrafting;
 import net.minecraft.world.WorldServer;
 
 import mods.railcraft.api.signals.AbstractPair;
@@ -68,14 +69,32 @@ public class PacketBuilder implements ISignalPacketBuilder {
         PacketDispatcher.sendToPlayer(pkt, player);
     }
 
+    public void sendGuiIntegerPacket(ICrafting crafter, int windowId, int key, int value) {
+        if (crafter instanceof EntityPlayerMP player) {
+            sendGuiIntegerPacket(player, windowId, key, value);
+        }
+    }
+
     public void sendGuiStringPacket(EntityPlayerMP player, int windowId, int key, String value) {
         PacketGuiString pkt = new PacketGuiString(windowId, key, value);
         PacketDispatcher.sendToPlayer(pkt, player);
     }
 
+    public void sendGuiStringPacket(ICrafting crafter, int windowId, int key, String value) {
+        if (crafter instanceof EntityPlayerMP player) {
+            sendGuiStringPacket(player, windowId, key, value);
+        }
+    }
+
     public void sendGuiWidgetPacket(EntityPlayerMP player, int windowId, int widgetId, byte[] data) {
         PacketGuiWidget pkt = new PacketGuiWidget(windowId, widgetId, data);
         PacketDispatcher.sendToPlayer(pkt, player);
+    }
+
+    public void sendGuiWidgetPacket(ICrafting crafter, int windowId, int widgetId, byte[] data) {
+        if (crafter instanceof EntityPlayerMP player) {
+            sendGuiWidgetPacket(player, windowId, widgetId, data);
+        }
     }
 
     public void sendGoldenTicketGuiPacket(EntityPlayerMP player) {


### PR DESCRIPTION
ICrafting should not be forcibly cast to EntityPlayerMP, as this will cause ClassCastException when other mods add classes that implement the interface

```
net.minecraft.util.ReportedException: Ticking entity
	at Launch//net.minecraft.server.MinecraftServer.func_71190_q(MinecraftServer.java:642) ~[MinecraftServer.class:?]
	at Launch//net.minecraft.server.dedicated.DedicatedServer.func_71190_q(DedicatedServer.java:334) ~[lt.class:?]
	at Launch//net.minecraft.server.MinecraftServer.func_71217_p(MinecraftServer.java:547) ~[MinecraftServer.class:?]
	at Launch//net.minecraft.server.MinecraftServer.run(MinecraftServer.java:427) [MinecraftServer.class:?]
	at Launch//net.minecraft.server.MinecraftServer$2.run(MinecraftServer.java:685) [li.class:?]
Caused by: java.lang.ClassCastException: class ruiseki.okcore.event.inventory.InventoryScanner$InventoryListener cannot be cast to class net.minecraft.entity.player.EntityPlayerMP (ruiseki.okcore.event.inventory.InventoryScanner$InventoryListener and net.minecraft.entity.player.EntityPlayerMP are in unnamed module of loader 'Launch' @687e99d8)
	at Launch//mods.railcraft.common.fluids.TankManager.updateGuiData(TankManager.java:167) ~[TankManager.class:?]
	at Launch//mods.railcraft.common.gui.containers.ContainerTank.sendUpdateToClient(ContainerTank.java:52) ~[ContainerTank.class:?]
	at Launch//mods.railcraft.common.gui.containers.RailcraftContainer.func_75142_b(RailcraftContainer.java:71) ~[RailcraftContainer.class:?]
	at Launch//net.minecraft.entity.player.EntityPlayerMP.localOnUpdate(EntityPlayerMP.java:212) ~[mw.class:?]
	at Launch//api.player.server.ServerPlayerAPI.onUpdate(ServerPlayerAPI.java:5888) ~[ServerPlayerAPI.class:?]
	at Launch//net.minecraft.entity.player.EntityPlayerMP.func_70071_h_(EntityPlayerMP.java) ~[mw.class:?]
	at Launch//net.minecraft.world.World.func_72866_a(World.java:2070) ~[ahb.class:?]
	at Launch//net.minecraft.world.WorldServer.func_72866_a(WorldServer.java:648) ~[mt.class:?]
	at Launch//net.minecraft.world.World.func_72870_g(World.java:2034) ~[ahb.class:?]
	at Launch//net.minecraft.world.World.func_72939_s(World.java:1887) ~[ahb.class:?]
	at Launch//net.minecraft.world.WorldServer.func_72939_s(WorldServer.java:489) ~[mt.class:?]
	at Launch//net.minecraft.server.MinecraftServer.func_71190_q(MinecraftServer.java:636) ~[MinecraftServer.class:?]
	... 4 more
```