### PR TITLE
Fix FirestoneTickHandler causing a CME

### DIFF
--- a/src/main/java/mods/railcraft/common/items/firestone/FirestoneTickHandler.java
+++ b/src/main/java/mods/railcraft/common/items/firestone/FirestoneTickHandler.java
@@ -5,6 +5,7 @@
  */
 package mods.railcraft.common.items.firestone;
 
+import java.util.LinkedList;
 import java.util.Random;
 
 import net.minecraft.block.Block;
@@ -66,18 +67,27 @@ public class FirestoneTickHandler {
         if (clock % 4 != 0) {
             return;
         }
+        LinkedList<int[]> fireBlocks = new LinkedList<>();
         for (Object o : event.world.loadedEntityList) {
             if (o instanceof EntityItem ei) {
                 ItemStack stack = ei.getEntityItem();
                 if (shouldBurn(stack)) {
-                    spawnFireEntity(event.world.rand, ei);
+                    int[] pos = spawnFireEntity(event.world.rand, ei);
+                    if (pos != null) {
+                        fireBlocks.add(pos);
+                    }
                 }
             }
         }
 
+        while (!fireBlocks.isEmpty()) {
+            int[] pos = fireBlocks.poll();
+            event.world.setBlock(pos[0], pos[1], pos[2], Blocks.fire);
+        }
+
     }
 
-    private boolean spawnFireEntity(Random rnd, Entity entity) {
+    private int[] spawnFireEntity(Random rnd, Entity entity) {
         int x = (int) Math.round(entity.posX) - 5 + rnd.nextInt(12);
         int y = (int) Math.round(entity.posY) - 5 + rnd.nextInt(12);
         int z = (int) Math.round(entity.posZ) - 5 + rnd.nextInt(12);
@@ -85,12 +95,15 @@ public class FirestoneTickHandler {
         if (y < 1) y = 1;
         if (y > entity.worldObj.getActualHeight()) y = entity.worldObj.getActualHeight() - 2;
 
-        if (canBurn(entity.worldObj, x, y, z)) return entity.worldObj.setBlock(x, y, z, Blocks.fire);
-        return false;
+        if (canBurn(entity.worldObj, x, y, z)) return new int[] { x, y, z };
+        return null;
     }
 
     private boolean spawnFire(EntityPlayer player) {
-        return spawnFireEntity(player.getRNG(), player);
+        int[] pos = spawnFireEntity(player.getRNG(), player);
+        if (pos == null) return false;
+        player.worldObj.setBlock(pos[0], pos[1], pos[2], Blocks.fire);
+        return true;
     }
 
     private boolean canBurn(World world, int x, int y, int z) {

--- a/src/main/java/mods/railcraft/common/items/firestone/FirestoneTickHandler.java
+++ b/src/main/java/mods/railcraft/common/items/firestone/FirestoneTickHandler.java
@@ -46,7 +46,7 @@ public class FirestoneTickHandler {
         if (event.side == Side.CLIENT || !RailcraftConfig.firestoneIgnitesBlocks) return;
         clock++;
         if (clock % 4 != 0) return;
-        EntityPlayer player = (EntityPlayer) event.player;
+        EntityPlayer player = event.player;
         if (player.openContainer != player.inventoryContainer) return;
         for (ItemStack stack : player.inventory.mainInventory) {
             if (shouldBurn(stack)) {
@@ -94,12 +94,13 @@ public class FirestoneTickHandler {
     }
 
     private boolean canBurn(World world, int x, int y, int z) {
+        if (!world.blockExists(x, y, z)) return false;
         if (world.getBlock(x, y, z) != Blocks.air) return false;
         for (ForgeDirection side : ForgeDirection.VALID_DIRECTIONS) {
             int sx = MiscTools.getXOnSide(x, side);
             int sy = MiscTools.getYOnSide(y, side);
             int sz = MiscTools.getZOnSide(z, side);
-            if (!world.isAirBlock(sx, sy, sz)) {
+            if (world.blockExists(sx, sy, sz) && !world.isAirBlock(sx, sy, sz)) {
                 Block block = WorldPlugin.getBlock(world, sx, sy, sz);
                 if (block != Blocks.fire) return true;
             }


### PR DESCRIPTION
The foreach-loop could place a fire block in an unloaded chunk, causing that chunk to load. If that chunk had any entities, a CME would occur as the list of loaded entities would be changed.

This PR fixes this by only placing fire blocks in loaded chunks. The fire blocks are also placed after the iteration as some mod interactions could cause setting a block to load chunks/spawn entities.

Closes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/25403
Closes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/24670

Tested in a world that would reliably crash due to this bug