### PR TITLE
Cache enum `.values()`

### DIFF
--- a/src/main/java/mods/railcraft/common/blocks/aesthetics/post/BlockPost.java
+++ b/src/main/java/mods/railcraft/common/blocks/aesthetics/post/BlockPost.java
@@ -85,7 +85,7 @@ public class BlockPost extends BlockPostBase implements IPostConnection {
 
     @Override
     public void getSubBlocks(Item item, CreativeTabs tab, List list) {
-        for (EnumPost post : EnumPost.values()) {
+        for (EnumPost post : EnumPost.VALUES) {
             if (post == EnumPost.EMBLEM) continue;
             list.add(post.getItem());
         }

--- a/src/main/java/mods/railcraft/common/blocks/aesthetics/post/EnumPost.java
+++ b/src/main/java/mods/railcraft/common/blocks/aesthetics/post/EnumPost.java
@@ -49,8 +49,8 @@ public enum EnumPost {
     }
 
     public static EnumPost fromId(int id) {
-        if (id < 0 || id >= EnumPost.values().length) id = 0;
-        return EnumPost.values()[id];
+        if (id < 0 || id >= EnumPost.VALUES.length) id = 0;
+        return EnumPost.VALUES[id];
     }
 
     public String getTag() {


### PR DESCRIPTION
## Summary
<!-- Briefly describe what this PR changes and why. -->
caching enum values() calls that got called more than 500 times during my little playtest.

## Checklist
- [ ] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
